### PR TITLE
`IGrowthbook` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2022-10-10]
+## [Unreleased]
 
 - Added a CHANGELOG.md based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added standard rules for markdown files in .editorconfig
 - Ensured that all files have a consistent line-ending (based on what they already have)
+- Added `IGrowthbook` interface
 
 ## [0.0.6] - 2022-06-07
 

--- a/GrowthBook/GrowthBook.cs
+++ b/GrowthBook/GrowthBook.cs
@@ -10,7 +10,7 @@ namespace GrowthBook
     //  feature flagging and A/B testing platform.
     //  More info at https://www.growthbook.io
     /// </summary>
-    public class GrowthBook : IDisposable
+    public class GrowthBook : IGrowthbook, IDisposable
     {
         // #region Private Members
 
@@ -114,33 +114,19 @@ namespace GrowthBook
 
         // #endregion
 
-        /// <summary>
-        /// Checks to see if a feature is on.
-        /// </summary>
-        /// <param name="key">The feature key.</param>
-        /// <returns>True if the feature is on.</returns>
+        /// <inheritdoc />
         public bool IsOn(string key)
         {
             return EvalFeature(key).On;
         }
 
-        /// <summary>
-        /// Checks to see if a feature is off.
-        /// </summary>
-        /// <param name="key">The feature key.</param>
-        /// <returns>True if the feature is off.</returns>
+        /// <inheritdoc />
         public bool IsOff(string key)
         {
             return EvalFeature(key).Off;
         }
 
-        /// <summary>
-        /// Gets the value of a feature cast to the specified type.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="key">The feature key.</param>
-        /// <param name="fallback">Fallback value to return if the feature is not on.</param>
-        /// <returns>Value of a feature cast to the specified type.</returns>
+        /// <inheritdoc />
         public T GetFeatureValue<T>(string key, T fallback)
         {
             FeatureResult result = EvalFeature(key);
@@ -151,32 +137,20 @@ namespace GrowthBook
             return fallback;
         }
 
-        /// <summary>
-        /// Returns a map of the latest results indexed by experiment key.
-        /// </summary>
-        /// <returns></returns>
+        /// <inheritdoc />
         public IDictionary<string, ExperimentAssignment> GetAllResults()
         {
             return _assigned;
         }
 
-        /// <summary>
-        /// Subscribes to a GrowthBook instance to be alerted every time growthbook.run is called.
-        /// This is different from the tracking callback since it also fires when a user is not included in an experiment.
-        /// </summary>
-        /// <param name="callback">The callback to trigger when growthbook.run is called.</param>
-        /// <returns>An action callback that can be used to unsubscribe.</returns>
+        /// <inheritdoc />
         public Action Subscribe(Action<Experiment, ExperimentResult> callback)
         {
             _subscriptions.Add(callback);
             return () => _subscriptions.Remove(callback);
         }
 
-        /// <summary>
-        /// Evaluates a feature and returns a feature result.
-        /// </summary>
-        /// <param name="key">The feature key.</param>
-        /// <returns>The feature result.</returns>
+        /// <inheritdoc />
         public FeatureResult EvalFeature(string key)
         {
             if (!Features.TryGetValue(key, out Feature feature))
@@ -238,11 +212,7 @@ namespace GrowthBook
             return new FeatureResult { Value = feature.DefaultValue, Source = "defaultValue" };
         }
 
-        /// <summary>
-        /// Evaluates an experiment and returns an experiment result.
-        /// </summary>
-        /// <param name="experiment">The experiment to evaluate.</param>
-        /// <returns>The experiment result.</returns>
+        /// <inheritdoc />
         public ExperimentResult Run(Experiment experiment)
         {
             ExperimentResult result = RunExperiment(experiment);

--- a/GrowthBook/IGrowthbook.cs
+++ b/GrowthBook/IGrowthbook.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+namespace GrowthBook
+{
+    /// <summary>
+    /// Providing operations to interact with feature flags.
+    /// </summary>
+    public interface IGrowthbook
+    {
+        /// <summary>
+        /// Checks to see if a feature is on.
+        /// </summary>
+        /// <param name="key">The feature key.</param>
+        /// <returns>True if the feature is on.</returns>
+        bool IsOn(string key);
+
+        /// <summary>
+        /// Checks to see if a feature is off.
+        /// </summary>
+        /// <param name="key">The feature key.</param>
+        /// <returns>True if the feature is off.</returns>
+        bool IsOff(string key);
+
+        /// <summary>
+        /// Gets the value of a feature cast to the specified type.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="key">The feature key.</param>
+        /// <param name="fallback">Fallback value to return if the feature is not on.</param>
+        /// <returns>Value of a feature cast to the specified type.</returns>
+        T GetFeatureValue<T>(string key, T fallback);
+
+        /// <summary>
+        /// Returns a map of the latest results indexed by experiment key.
+        /// </summary>
+        /// <returns></returns>
+        IDictionary<string, ExperimentAssignment> GetAllResults();
+
+        /// <summary>
+        /// Subscribes to a GrowthBook instance to be alerted every time growthbook.run is called.
+        /// This is different from the tracking callback since it also fires when a user is not included in an experiment.
+        /// </summary>
+        /// <param name="callback">The callback to trigger when growthbook.run is called.</param>
+        /// <returns>An action callback that can be used to unsubscribe.</returns>
+        Action Subscribe(Action<Experiment, ExperimentResult> callback);
+
+        /// <summary>
+        /// Evaluates a feature and returns a feature result.
+        /// </summary>
+        /// <param name="key">The feature key.</param>
+        /// <returns>The feature result.</returns>
+        FeatureResult EvalFeature(string key);
+
+        /// <summary>
+        /// Evaluates an experiment and returns an experiment result.
+        /// </summary>
+        /// <param name="experiment">The experiment to evaluate.</param>
+        /// <returns>The experiment result.</returns>
+        ExperimentResult Run(Experiment experiment);
+    }
+}


### PR DESCRIPTION
We're currently using this package for our applications within our company. Having an interface (to provide operations to interact with feature flags) would make it easier to mock Growthbook within unit tests for business logic.

With having an interface, we can use Growthbook like this in untit tests (this example is using [AutoFixture](https://github.com/AutoFixture/AutoFixture) and [Moq](https://github.com/devlooped/moq)):
```csharp
[Theory]
public async Task TestFeaturesBehaviour(IFixture fixture, [Frozen] Mock<IGrowthbook> growthbookMock, ServiceToTest serviceToTest)
{
 // Arrange  
 growthbookMock.Setup(m => m.IsOn("Myfeature")).Returns(true);
 
  // Act
  serviceToTest.FunctionToTest();
  
  // Assert
 ...
}
```