### PR TITLE
Fixed differing null/empty evaluation during non-array IsIn condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1]
+
+- Fixed issue with empty string value sent to IsIn condition evaluation.
+
 ## [1.0.0]
 
 - Fully implemented version 0.5.2 of the GrowthBook SDK spec.

--- a/GrowthBook.Tests/CustomTests/RegressionTests.cs
+++ b/GrowthBook.Tests/CustomTests/RegressionTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace GrowthBook.Tests.CustomTests;
+
+public class RegressionTests : UnitTest
+{
+    [Fact]
+    public void EvalIsInConditionShouldNotDifferWhenAttributeIsEmptyInsteadOfNull()
+    {
+        var featureJson = """
+            {
+                "defaultValue": false,
+                "rules": [
+                    {
+                        "condition": {
+                        "userId": {
+                            "$in": [
+                            "ac1",
+                            "ac2",
+                            "ac3"
+                            ]
+                        }
+                        },
+                        "force": true
+                    }
+                ]
+            }
+            """;
+
+        var feature = JsonConvert.DeserializeObject<Feature>(featureJson);
+
+        var staticFeatures = new Dictionary<string, Feature>
+        {
+            ["test-in-op"] = feature
+        };
+
+        var context = new Context
+        {
+            Features = staticFeatures
+        };
+
+        var growthBook = new GrowthBook(context);
+
+        // The initial evaluation will use a null userId value.
+
+        var flag = growthBook.IsOn("test-in-op");
+        flag.Should().BeFalse("because the userId property in the attributes JSON is null");
+
+        // Try again with a userId that is an empty string instead.
+
+        context.Attributes.Add("userId", string.Empty);
+
+        var errorFlag = growthBook.IsOn("test-in-op");
+        errorFlag.Should().BeFalse("because an empty string is considered falsy and should not differ from the null case");
+    }
+}

--- a/GrowthBook/Extensions/JsonExtensions.cs
+++ b/GrowthBook/Extensions/JsonExtensions.cs
@@ -23,6 +23,13 @@ namespace GrowthBook.Extensions
         public static bool IsNull(this JToken token) => token is null || token.Type == JTokenType.Null;
 
         /// <summary>
+        /// Determines whether the <see cref="JToken"/> is either null, <see cref="JTokenType.Null"/>, an empty string, or whitespace.
+        /// </summary>
+        /// <param name="token">The JSON token to verify.</param>
+        /// <returns>True if null, empty, or whitespace, false otherwise.</returns>
+        public static bool IsNullOrWhitespace(this JToken token) => token.IsNull() || token.ToString().IsNullOrWhitespace();
+
+        /// <summary>
         /// Gets the value of the named attribute key within the current <see cref="JObject"/>.
         /// </summary>
         /// <param name="json">The JSON object to look up the key from.</param>

--- a/GrowthBook/GrowthBook.csproj
+++ b/GrowthBook/GrowthBook.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/growthbook/growthbook-csharp.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>GrowthBook,A/B test,feature toggle,flag</PackageTags>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Title>GrowthBook C# SDK</Title>
     <PackageProjectUrl>https://www.growthbook.io/</PackageProjectUrl>
   </PropertyGroup>

--- a/GrowthBook/Providers/ConditionEvaluationProvider.cs
+++ b/GrowthBook/Providers/ConditionEvaluationProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using GrowthBook.Extensions;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 
@@ -383,7 +384,7 @@ namespace GrowthBook.Providers
                     return true;
                 }
 
-                if (conditionValue is null || actualValue is null)
+                if (conditionValue.IsNullOrWhitespace() || actualValue.IsNullOrWhitespace())
                 {
                     return false;
                 }


### PR DESCRIPTION
The logic of the `ConditionEvaluationProvider.IsIn()` call was incorrectly checking for only a null value when a non-array actual value was present, which made the behavior mark features as enabled when they should have been disabled. Changed this to do an actual `IsNullOrWhitespace()` verification on the non-array token instead to fix the issue.

This PR is to address issue #24.