### PR TITLE
Fixed incorrect implementation of GetFeatureResult call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2]
+
+- Fixed issue with incorrect logic in GrowthBook.GetFeatureResult<T>() call.
+
 ## [1.0.1]
 
 - Fixed issue with empty string value sent to IsIn condition evaluation.

--- a/GrowthBook.Tests/CustomTests/RegressionTests.cs
+++ b/GrowthBook.Tests/CustomTests/RegressionTests.cs
@@ -12,6 +12,39 @@ namespace GrowthBook.Tests.CustomTests;
 public class RegressionTests : UnitTest
 {
     [Fact]
+    public void GetFeatureValueShouldOnlyReturnFallbackValueWhenTheFeatureResultValueIsNull()
+    {
+        const string FeatureName = "test-false-default-value";
+
+        var feature = new Feature { DefaultValue = false };
+
+        var staticFeatures = new Dictionary<string, Feature>
+        {
+            [FeatureName] = feature
+        };
+
+        var context = new Context
+        {
+            Features = staticFeatures
+        };
+
+        var growthBook = new GrowthBook(context);
+
+        growthBook.IsOn(FeatureName).Should().BeFalse("because the value of the feature is considered falsy");
+        growthBook.GetFeatureValue(FeatureName, true).Should().BeFalse("because the default value can be served from the feature");
+
+        growthBook.Features[FeatureName] = new Feature { DefaultValue = null };
+
+        growthBook.IsOn(FeatureName).Should().BeFalse("because the value of the feature is considered falsy");
+        growthBook.GetFeatureValue(FeatureName, false).Should().BeFalse("because the fallback value should be returned when the result value is null");
+
+        growthBook.Features[FeatureName] = new Feature { DefaultValue = true };
+
+        growthBook.IsOn(FeatureName).Should().BeTrue("because the value of the feature is considered truthy");
+        growthBook.GetFeatureValue(FeatureName, false).Should().BeTrue("because the default value can be served from the feature");
+    }
+
+    [Fact]
     public void EvalIsInConditionShouldNotDifferWhenAttributeIsEmptyInsteadOfNull()
     {
         var featureJson = """

--- a/GrowthBook/GrowthBook.cs
+++ b/GrowthBook/GrowthBook.cs
@@ -168,12 +168,9 @@ namespace GrowthBook
         /// <inheritdoc />
         public T GetFeatureValue<T>(string key, T fallback)
         {
-            FeatureResult result = EvalFeature(key);
-            if (result.On)
-            {
-                return result.Value.ToObject<T>();
-            }
-            return fallback;
+            var value = EvalFeature(key).Value;
+
+            return value.IsNull() ? fallback : value.ToObject<T>();
         }
 
         /// <inheritdoc />

--- a/GrowthBook/GrowthBook.csproj
+++ b/GrowthBook/GrowthBook.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/growthbook/growthbook-csharp.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>GrowthBook,A/B test,feature toggle,flag</PackageTags>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Title>GrowthBook C# SDK</Title>
     <PackageProjectUrl>https://www.growthbook.io/</PackageProjectUrl>
   </PropertyGroup>


### PR DESCRIPTION
The `GrowthBook.GetFeatureValue<T>()` call was incorrectly checking whether the feature was marked as On to determine whether or not to return the fallback value. This has been changed to only use a null check there instead, as per [the spec.](https://docs.growthbook.io/lib/build-your-own#feature-helper-methods)

This should fix #22.