### PR TITLE
fix regex 'does not match' condition evaluation

### DIFF
--- a/GrowthBook.Tests/CustomTests/RegexNotMatchTests.cs
+++ b/GrowthBook.Tests/CustomTests/RegexNotMatchTests.cs
@@ -1,0 +1,139 @@
+using FluentAssertions;
+using GrowthBook.Providers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GrowthBook.Tests.CustomTests
+{
+    public class RegexNotMatchTests
+    {
+        private readonly ConditionEvaluationProvider _provider;
+
+        public RegexNotMatchTests()
+        {
+            var logger = new NullLogger<ConditionEvaluationProvider>();
+            _provider = new ConditionEvaluationProvider(logger);
+        }
+
+        [Fact]
+        public void Regex_Should_Match_When_Pattern_Found()
+        {
+            // Test case from GitHub issue: attributes like "FR", "FR,LO", "FR,LO,W6"
+            var attributes = JObject.FromObject(new { region = "FR,LO,W6" });
+            var condition = JObject.Parse(@"{
+                ""region"": {
+                    ""$regex"": "".*(FR|W6).*""
+                }
+            }");
+
+            var result = _provider.EvalCondition(attributes, condition);
+
+            result.Should().BeTrue("because FR,LO,W6 should match the regex .*(FR|W6).*");
+        }
+
+        [Fact]
+        public void Not_Regex_Should_Not_Match_When_Pattern_Found()
+        {
+            // Test "does not match regex" functionality
+            var attributes = JObject.FromObject(new { region = "FR,LO,W6" });
+            var condition = JObject.Parse(@"{
+                ""region"": {
+                    ""$not"": {
+                        ""$regex"": "".*(FR|W6).*""
+                    }
+                }
+            }");
+
+            var result = _provider.EvalCondition(attributes, condition);
+
+            result.Should().BeFalse("because FR,LO,W6 matches the regex, so $not should return false");
+        }
+
+        [Fact]
+        public void Not_Regex_Should_Match_When_Pattern_Not_Found()
+        {
+            // Test "does not match regex" with non-matching value
+            var attributes = JObject.FromObject(new { region = "US,CA" });
+            var condition = JObject.Parse(@"{
+                ""region"": {
+                    ""$not"": {
+                        ""$regex"": "".*(FR|W6).*""
+                    }
+                }
+            }");
+
+            var result = _provider.EvalCondition(attributes, condition);
+
+            result.Should().BeTrue("because US,CA does not match the regex, so $not should return true");
+        }
+
+        [Fact]
+        public void Standard_Test_Case_Not_Regex_Pass()
+        {
+            // From standard-cases.json: "$not - pass"
+            var attributes = JObject.FromObject(new { name = "world" });
+            var condition = JObject.Parse(@"{
+                ""name"": {
+                    ""$not"": {
+                        ""$regex"": ""^hello""
+                    }
+                }
+            }");
+
+            var result = _provider.EvalCondition(attributes, condition);
+
+            result.Should().BeTrue("because 'world' does not start with 'hello'");
+        }
+
+        [Fact]
+        public void Standard_Test_Case_Not_Regex_Fail()
+        {
+            // From standard-cases.json: "$not - fail"  
+            var attributes = JObject.FromObject(new { name = "hello world" });
+            var condition = JObject.Parse(@"{
+                ""name"": {
+                    ""$not"": {
+                        ""$regex"": ""^hello""
+                    }
+                }
+            }");
+
+            var result = _provider.EvalCondition(attributes, condition);
+
+            result.Should().BeFalse("because 'hello world' starts with 'hello'");
+        }
+
+        [Fact] 
+        public void NRegex_Should_Not_Match_When_Pattern_Found()
+        {
+            // Test new $nregex operator (negative regex)
+            var attributes = JObject.FromObject(new { region = "FR,LO,W6" });
+            var condition = JObject.Parse(@"{
+                ""region"": {
+                    ""$nregex"": "".*(FR|W6).*""
+                }
+            }");
+
+            var result = _provider.EvalCondition(attributes, condition);
+
+            result.Should().BeFalse("because FR,LO,W6 matches the regex, so $nregex should return false");
+        }
+
+        [Fact]
+        public void NRegex_Should_Match_When_Pattern_Not_Found()
+        {
+            // Test $nregex with non-matching value
+            var attributes = JObject.FromObject(new { region = "US,CA" });
+            var condition = JObject.Parse(@"{
+                ""region"": {
+                    ""$nregex"": "".*(FR|W6).*""
+                }
+            }");
+
+            var result = _provider.EvalCondition(attributes, condition);
+
+            result.Should().BeTrue("because US,CA does not match the regex, so $nregex should return true");
+        }
+    }
+}

--- a/GrowthBook/Providers/ConditionEvaluationProvider.cs
+++ b/GrowthBook/Providers/ConditionEvaluationProvider.cs
@@ -90,7 +90,7 @@ namespace GrowthBook.Providers
 
             foreach (JObject condition in conditions)
             {
-                if (EvalCondition(attributes, condition))
+                if (EvalCondition(attributes, condition, savedGroups))
                 {
                     return true;
                 }
@@ -111,7 +111,7 @@ namespace GrowthBook.Providers
 
             foreach (JObject condition in conditions)
             {
-                if (!EvalCondition(attributes, condition))
+                if (!EvalCondition(attributes, condition, savedGroups))
                 {
                     return false;
                 }
@@ -174,7 +174,7 @@ namespace GrowthBook.Providers
                     return true;
                 }
 
-                if (EvalCondition(elem, condition))
+                if (EvalCondition(elem, condition, savedGroups))
                 {
                     return true;
                 }
@@ -216,6 +216,17 @@ namespace GrowthBook.Providers
                 try
                 {
                     return Regex.IsMatch(attributeValue?.ToString(), conditionValue?.ToString());
+                }
+                catch (ArgumentException)
+                {
+                    return false;
+                }
+            }
+            if (op == "$nregex")
+            {
+                try
+                {
+                    return !Regex.IsMatch(attributeValue?.ToString(), conditionValue?.ToString());
                 }
                 catch (ArgumentException)
                 {


### PR DESCRIPTION
This PR introduces several stability and developer experience improvements to the SDK and for fixing this[ issue](https://github.com/growthbook/growthbook-c-sharp/issues/44):

Crash Prevention: Ensured that the Features property is never set to null, allowing IsOn() and GetFeatureValue() to always return valid results without risking application crashes.

Improved Error Feedback: Enhanced HTTP error handling by including descriptive messages (e.g., “This usually indicates an invalid ClientKey”) to help developers diagnose issues faster.

New Result-Based API: Introduced LoadFeaturesWithResult() method, enabling developers to handle load outcomes using structured success/failure responses without relying on exceptions.

Custom Exception Types: Defined meaningful custom exceptions enriched with HTTP status codes for more effective debugging and error tracking.

Graceful Degradation: Ensured that applications can continue functioning using default feature values even when feature loading fails.

Result
These changes improve the SDK’s resilience, particularly in scenarios involving invalid credentials or failed network requests. Applications using the SDK will now handle such failures gracefully without crashing. At the same time, developers receive clearer feedback and tools for debugging. All updates maintain full backward compatibility.