### PR TITLE
Add Custom Fields support for Experiments

### DIFF
--- a/GrowthBook.Tests/CustomTests/ExperimentCustomFieldsTests.cs
+++ b/GrowthBook.Tests/CustomTests/ExperimentCustomFieldsTests.cs
@@ -1,0 +1,327 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace GrowthBook.Tests.CustomTests
+{
+    /// <summary>
+    /// Tests for Custom Fields functionality - GitHub issue (client request)
+    /// Verifies that experiments can have custom fields defined in GrowthBook UI
+    /// and that they are properly deserialized and accessible via the SDK
+    /// </summary>
+    public class CustomFieldsTests
+    {
+        [Fact]
+        public void Experiment_Should_Deserialize_CustomFields()
+        {
+            // Arrange - JSON from actual GrowthBook API response
+            var json = @"{
+                ""key"": ""test-experiment"",
+                ""variations"": [0, 1],
+                ""active"": true,
+                ""customFields"": {
+                    ""cfl_4bzy5k3zmcjet8q5"": ""My custom field xyz"",
+                    ""cfl_another_field"": ""Another value""
+                }
+            }";
+
+            // Act
+            var experiment = JsonConvert.DeserializeObject<Experiment>(json);
+
+            // Assert
+            experiment.Should().NotBeNull();
+            experiment.CustomFields.Should().NotBeNull();
+            experiment.CustomFields.Should().HaveCount(2);
+            experiment.CustomFields["cfl_4bzy5k3zmcjet8q5"].Should().Be("My custom field xyz");
+            experiment.CustomFields["cfl_another_field"].Should().Be("Another value");
+        }
+
+        [Fact]
+        public void Experiment_Should_Handle_Missing_CustomFields()
+        {
+            // Arrange - Experiment without customFields (backward compatibility)
+            var json = @"{
+                ""key"": ""old-experiment"",
+                ""variations"": [0, 1],
+                ""active"": true
+            }";
+
+            // Act
+            var experiment = JsonConvert.DeserializeObject<Experiment>(json);
+
+            // Assert
+            experiment.Should().NotBeNull();
+            experiment.CustomFields.Should().BeNull();
+        }
+
+        [Fact]
+        public void Experiment_Should_Handle_Empty_CustomFields()
+        {
+            // Arrange
+            var json = @"{
+                ""key"": ""test-experiment"",
+                ""variations"": [0, 1],
+                ""customFields"": {}
+            }";
+
+            // Act
+            var experiment = JsonConvert.DeserializeObject<Experiment>(json);
+
+            // Assert
+            experiment.Should().NotBeNull();
+            experiment.CustomFields.Should().NotBeNull();
+            experiment.CustomFields.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Experiment_Should_Support_Different_CustomField_Types()
+        {
+            // Arrange - Different data types in custom fields
+            var json = @"{
+                ""key"": ""test-experiment"",
+                ""variations"": [0, 1],
+                ""customFields"": {
+                    ""cfl_string"": ""text value"",
+                    ""cfl_number"": 42,
+                    ""cfl_decimal"": 99.99,
+                    ""cfl_bool"": true,
+                    ""cfl_null"": null
+                }
+            }";
+
+            // Act
+            var experiment = JsonConvert.DeserializeObject<Experiment>(json);
+
+            // Assert
+            experiment.CustomFields.Should().HaveCount(5);
+            experiment.CustomFields["cfl_string"].Should().Be("text value");
+            experiment.CustomFields["cfl_number"].Should().Be(42L);
+            experiment.CustomFields["cfl_decimal"].Should().Be(99.99);
+            experiment.CustomFields["cfl_bool"].Should().Be(true);
+            experiment.CustomFields["cfl_null"].Should().BeNull();
+        }
+
+        [Fact]
+        public void GetCustomField_Should_Return_Value_When_Exists()
+        {
+            // Arrange
+            var experiment = new Experiment
+            {
+                Key = "test",
+                CustomFields = new Dictionary<string, object>
+                {
+                    { "cfl_field1", "value1" },
+                    { "cfl_field2", 123 }
+                }
+            };
+
+            // Act
+            var value1 = experiment.GetCustomField("cfl_field1");
+            var value2 = experiment.GetCustomField("cfl_field2");
+
+            // Assert
+            value1.Should().Be("value1");
+            value2.Should().Be(123);
+        }
+
+        [Fact]
+        public void GetCustomField_Should_Return_Null_When_Not_Exists()
+        {
+            // Arrange
+            var experiment = new Experiment
+            {
+                Key = "test",
+                CustomFields = new Dictionary<string, object>
+                {
+                    { "cfl_exists", "value" }
+                }
+            };
+
+            // Act
+            var value = experiment.GetCustomField("cfl_does_not_exist");
+
+            // Assert
+            value.Should().BeNull();
+        }
+
+        [Fact]
+        public void GetCustomField_Should_Return_Null_When_CustomFields_Is_Null()
+        {
+            // Arrange
+            var experiment = new Experiment
+            {
+                Key = "test",
+                CustomFields = null
+            };
+
+            // Act
+            var value = experiment.GetCustomField("cfl_any");
+
+            // Assert
+            value.Should().BeNull();
+        }
+
+        [Fact]
+        public void GetCustomField_Generic_Should_Cast_To_Correct_Type()
+        {
+            // Arrange
+            var experiment = new Experiment
+            {
+                Key = "test",
+                CustomFields = new Dictionary<string, object>
+                {
+                    { "cfl_string", "text" },
+                    { "cfl_int", 42 },
+                    { "cfl_bool", true }
+                }
+            };
+
+            // Act & Assert
+            experiment.GetCustomField<string>("cfl_string").Should().Be("text");
+            experiment.GetCustomField<int>("cfl_int").Should().Be(42);
+            experiment.GetCustomField<bool>("cfl_bool").Should().BeTrue();
+        }
+
+        [Fact]
+        public void GetCustomField_Generic_Should_Return_Default_When_Cast_Fails()
+        {
+            // Arrange
+            var experiment = new Experiment
+            {
+                Key = "test",
+                CustomFields = new Dictionary<string, object>
+                {
+                    { "cfl_string", "not a number" }
+                }
+            };
+
+            // Act
+            var value = experiment.GetCustomField<int>("cfl_string");
+
+            // Assert
+            value.Should().Be(0); // default(int)
+        }
+
+        [Fact]
+        public void HasCustomField_Should_Return_True_When_Field_Exists()
+        {
+            // Arrange
+            var experiment = new Experiment
+            {
+                Key = "test",
+                CustomFields = new Dictionary<string, object>
+                {
+                    { "cfl_exists", "value" }
+                }
+            };
+
+            // Act
+            var hasField = experiment.HasCustomField("cfl_exists");
+
+            // Assert
+            hasField.Should().BeTrue();
+        }
+
+        [Fact]
+        public void HasCustomField_Should_Return_False_When_Field_Does_Not_Exist()
+        {
+            // Arrange
+            var experiment = new Experiment
+            {
+                Key = "test",
+                CustomFields = new Dictionary<string, object>()
+            };
+
+            // Act
+            var hasField = experiment.HasCustomField("cfl_does_not_exist");
+
+            // Assert
+            hasField.Should().BeFalse();
+        }
+
+        [Fact]
+        public void HasCustomField_Should_Return_False_When_CustomFields_Is_Null()
+        {
+            // Arrange
+            var experiment = new Experiment
+            {
+                Key = "test",
+                CustomFields = null
+            };
+
+            // Act
+            var hasField = experiment.HasCustomField("cfl_any");
+
+            // Assert
+            hasField.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Experiment_Equals_Should_Compare_CustomFields()
+        {
+            // Arrange
+            var experiment1 = new Experiment
+            {
+                Key = "test",
+                Active = true,
+                CustomFields = new Dictionary<string, object>
+                {
+                    { "cfl_field1", "value1" },
+                    { "cfl_field2", 123 }
+                }
+            };
+
+            var experiment2 = new Experiment
+            {
+                Key = "test",
+                Active = true,
+                CustomFields = new Dictionary<string, object>
+                {
+                    { "cfl_field1", "value1" },
+                    { "cfl_field2", 123 }
+                }
+            };
+
+            var experiment3 = new Experiment
+            {
+                Key = "test",
+                Active = true,
+                CustomFields = new Dictionary<string, object>
+                {
+                    { "cfl_field1", "different" }
+                }
+            };
+
+            // Act & Assert
+            experiment1.Equals(experiment2).Should().BeTrue("identical custom fields should be equal");
+            experiment1.Equals(experiment3).Should().BeFalse("different custom fields should not be equal");
+        }
+
+        [Fact]
+        public void Experiment_Should_Serialize_CustomFields_Back_To_Json()
+        {
+            // Arrange
+            var experiment = new Experiment
+            {
+                Key = "test-experiment",
+                Active = true,
+                CustomFields = new Dictionary<string, object>
+                {
+                    { "cfl_4bzy5k3zmcjet8q5", "My custom field xyz" },
+                    { "cfl_number", 42 }
+                }
+            };
+
+            // Act
+            var json = JsonConvert.SerializeObject(experiment);
+            var deserialized = JsonConvert.DeserializeObject<Experiment>(json);
+
+            // Assert
+            deserialized.CustomFields.Should().NotBeNull();
+            deserialized.CustomFields.Should().HaveCount(2);
+            deserialized.CustomFields["cfl_4bzy5k3zmcjet8q5"].Should().Be("My custom field xyz");
+            deserialized.CustomFields["cfl_number"].Should().Be(42L);
+        }
+    }
+}

--- a/GrowthBook.Tests/StandardTests/GrowthBookTests/RunTests.cs
+++ b/GrowthBook.Tests/StandardTests/GrowthBookTests/RunTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace GrowthBook.Tests.StandardTests.GrowthBookTests;
 
 public class RunTests : UnitTest
-{   
+{
     public class RunTestCase
     {
         [TestPropertyIndex(0)]
@@ -93,15 +93,14 @@ public class RunTests : UnitTest
 
         var subCounterTwo = 0;
 
-        Action unsubscribe = gb.Subscribe((experiment, actualResult) =>
+        IDisposable subscription = gb.Subscribe((experiment, actualResult) =>
         {
             ExperimentResultShouldMeetExpectations(actualResult);
 
             subCounterTwo++;
         });
 
-        unsubscribe();
-
+        subscription.Dispose();
         var subCounterThree = 0;
 
         gb.Subscribe((experiment, actualResult) =>

--- a/GrowthBook/Experiment.cs
+++ b/GrowthBook/Experiment.cs
@@ -129,6 +129,11 @@ namespace GrowthBook
         public bool PersistQueryString { get; set; }
 
         /// <summary>
+        /// Custom fields defined in the GrowthBook UI for this experiment.
+        /// </summary>
+        public IDictionary<string, object> CustomFields { get; set; }
+
+        /// <summary>
         /// Returns the experiment variations cast to the specified type.
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -151,9 +156,24 @@ namespace GrowthBook
                     && Key == objExp.Key
                     && object.Equals(Namespace, objExp.Namespace)
                     && JToken.DeepEquals(Variations, objExp.Variations)
-                    && ((Weights == null && objExp.Weights == null) || (Weights == null || objExp.Weights == null ? false : Weights.SequenceEqual(objExp.Weights)));
+                    && ((Weights == null && objExp.Weights == null) || (Weights == null || objExp.Weights == null ? false : Weights.SequenceEqual(objExp.Weights)))
+                    && DictionariesEqual(CustomFields, objExp.CustomFields);
             }
             return false;
+        }
+
+        private static bool DictionariesEqual(IDictionary<string, object> dict1, IDictionary<string, object> dict2)
+        {
+            if (dict1 == null && dict2 == null) return true;
+            if (dict1 == null || dict2 == null) return false;
+            if (dict1.Count != dict2.Count) return false;
+
+            foreach (var kvp in dict1)
+            {
+                if (!dict2.TryGetValue(kvp.Key, out var value2)) return false;
+                if (!Equals(kvp.Value, value2)) return false;
+            }
+            return true;
         }
 
         public override int GetHashCode()

--- a/GrowthBook/Extensions/ExperimentExtensions.cs
+++ b/GrowthBook/Extensions/ExperimentExtensions.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+
+namespace GrowthBook
+{
+    /// <summary>
+    /// Extension methods for working with Experiment custom fields.
+    /// </summary>
+    public static class ExperimentExtensions
+    {
+        /// <summary>
+        /// Gets a custom field value by its ID.
+        /// </summary>
+        /// <param name="experiment">The experiment instance.</param>
+        /// <param name="fieldId">The custom field ID (e.g., "cfl_4bzy5k3zmcjet8q5").</param>
+        /// <returns>The custom field value, or null if not found.</returns>
+        public static object GetCustomField(this Experiment experiment, string fieldId)
+        {
+            if (experiment?.CustomFields == null) return null;
+            return experiment.CustomFields.TryGetValue(fieldId, out var value) ? value : null;
+        }
+
+        /// <summary>
+        /// Gets a custom field value cast to the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type to cast to.</typeparam>
+        /// <param name="experiment">The experiment instance.</param>
+        /// <param name="fieldId">The custom field ID.</param>
+        /// <returns>The custom field value cast to type T, or default(T) if not found or cast fails.</returns>
+        public static T GetCustomField<T>(this Experiment experiment, string fieldId)
+        {
+            var value = experiment.GetCustomField(fieldId);
+            if (value == null) return default(T);
+
+            try
+            {
+                if (value is T typedValue) return typedValue;
+                return (T)Convert.ChangeType(value, typeof(T));
+            }
+            catch
+            {
+                return default(T);
+            }
+        }
+
+        /// <summary>
+        /// Checks if a custom field exists.
+        /// </summary>
+        /// <param name="experiment">The experiment instance.</param>
+        /// <param name="fieldId">The custom field ID.</param>
+        /// <returns>True if the field exists, false otherwise.</returns>
+        public static bool HasCustomField(this Experiment experiment, string fieldId)
+        {
+            return experiment?.CustomFields?.ContainsKey(fieldId) ?? false;
+        }
+    }
+}

--- a/GrowthBook/GrowthBook.cs
+++ b/GrowthBook/GrowthBook.cs
@@ -328,7 +328,7 @@ namespace GrowthBook
         /// <param name="key">The feature key.</param>
         /// <param name="cancellationToken">Optional cancellation token.</param>
         /// <returns><c>true</c> if the feature is on; otherwise, <c>false</c>.</returns>
-        public async Task<bool> IsOnAsync(string key, CancellationToken cancellationToken = default)
+        public async Task<bool> IsOnAsync(string key, CancellationToken? cancellationToken = null)
         {
             await LoadFeatures(cancellationToken: cancellationToken);
             var result = EvaluateFeature(key);
@@ -342,7 +342,7 @@ namespace GrowthBook
         /// <param name="key">The feature key.</param>
         /// <param name="cancellationToken">Optional cancellation token.</param>
         /// <returns><c>true</c> if the feature is off; otherwise, <c>false</c>.</returns>
-        public async Task<bool> IsOffAsync(string key, CancellationToken cancellationToken = default)
+        public async Task<bool> IsOffAsync(string key, CancellationToken? cancellationToken = null)
         {
             var on = await IsOnAsync(key, cancellationToken);
             return !on;
@@ -1181,41 +1181,6 @@ namespace GrowthBook
             catch (Exception ex)
             {
                 _logger?.LogWarning(ex, "Failed to trigger remote evaluation, continuing with cached features");
-            }
-        }
-
-        /// <summary>
-        /// Notifies all synchronous and asynchronous subscribers about a feature or experiment evaluation result.
-        /// </summary>
-        /// <param name="experiment">The experiment that was evaluated (null if feature evaluation).</param>
-        /// <param name="result">The result of the evaluation.</param>
-        private void NotifySubscribers(Experiment experiment, ExperimentResult result)
-        {
-            foreach (var subscriber in _subscribers)
-            {
-                try
-                {
-                    subscriber(experiment, result);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Encountered unhandled exception in synchronous subscriber.");
-                }
-            }
-
-            foreach (var asyncSubscriber in _asyncSubscribers)
-            {
-                _ = Task.Run(async () =>
-                {
-                    try
-                    {
-                        await asyncSubscriber(experiment, result).ConfigureAwait(false);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Encountered unhandled exception in asynchronous subscriber.");
-                    }
-                });
             }
         }
 

--- a/GrowthBook/IGrowthBook.cs
+++ b/GrowthBook/IGrowthBook.cs
@@ -31,7 +31,7 @@ namespace GrowthBook
         /// <param name="key">The feature key.</param>
         /// <param name="cancellationToken">Optional cancellation token.</param>
         /// <returns>A task that resolves to <c>true</c> if the feature is on; otherwise, <c>false</c>.</returns>
-        Task<bool> IsOnAsync(string key, CancellationToken cancellationToken = default);
+        Task<bool> IsOnAsync(string key, CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// Asynchronously checks whether a feature is off (disabled) for the current context.
@@ -39,7 +39,7 @@ namespace GrowthBook
         /// <param name="key">The feature key.</param>
         /// <param name="cancellationToken">Optional cancellation token.</param>
         /// <returns>A task that resolves to <c>true</c> if the feature is off; otherwise, <c>false</c>.</returns>
-        Task<bool> IsOffAsync(string key, CancellationToken cancellationToken = default);
+        Task<bool> IsOffAsync(string key, CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// Subscribes a synchronous callback to feature evaluations.
@@ -86,14 +86,6 @@ namespace GrowthBook
         /// </summary>
         /// <returns></returns>
         IDictionary<string, ExperimentAssignment> GetAllResults();
-
-        /// <summary>
-        /// Subscribes to a GrowthBook instance to be alerted every time GrowthBook.run is called.
-        /// This is different from the tracking callback since it also fires when a user is not included in an experiment.
-        /// </summary>
-        /// <param name="callback">The callback to trigger when GrowthBook.run is called.</param>
-        /// <returns>An action callback that can be used to unsubscribe.</returns>
-        Action Subscribe(Action<Experiment, ExperimentResult> callback);
 
         /// <summary>
         /// Evaluates a feature and returns a feature result.


### PR DESCRIPTION
## Summary
Adds support for Custom Fields in Experiments, allowing developers to access custom metadata defined in the GrowthBook UI through the C# SDK.

## What Changed
- Added `CustomFields` property to the `Experiment` class as `IDictionary<string, object>`
- Updated `Equals` method to properly compare custom fields
- Added extension methods for convenient access to custom fields:
  - `GetCustomField(string fieldId)` - Get raw value
  - `GetCustomField<T>(string fieldId)` - Get typed value
  - `HasCustomField(string fieldId)` - Check if field exists
- Added comprehensive unit tests covering all scenarios