### PR TITLE
fix: minExperimentBucketVersion comparison

### DIFF
--- a/GrowthBook.Tests/StandardTests/GrowthBookTests/RunTests.cs
+++ b/GrowthBook.Tests/StandardTests/GrowthBookTests/RunTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace GrowthBook.Tests.StandardTests.GrowthBookTests;
 
 public class RunTests : UnitTest
-{   
+{
     public class RunTestCase
     {
         [TestPropertyIndex(0)]
@@ -93,14 +93,14 @@ public class RunTests : UnitTest
 
         var subCounterTwo = 0;
 
-        Action unsubscribe = gb.Subscribe((experiment, actualResult) =>
+        IDisposable subscription = gb.Subscribe((experiment, actualResult) =>
         {
             ExperimentResultShouldMeetExpectations(actualResult);
 
             subCounterTwo++;
         });
 
-        unsubscribe();
+        subscription.Dispose();
 
         var subCounterThree = 0;
 

--- a/GrowthBook/GrowthBook.cs
+++ b/GrowthBook/GrowthBook.cs
@@ -29,7 +29,6 @@ namespace GrowthBook
         private readonly Dictionary<string, ExperimentAssignment> _assigned;
         private readonly ConcurrentDictionary<string, byte> _tracked;
         private Action<Experiment, ExperimentResult> _trackingCallback;
-        private readonly List<Action<Experiment, ExperimentResult>> _subscriptions;
         private bool _disposedValue;
         private readonly IConditionEvaluationProvider _conditionEvaluator;
         private readonly IGrowthBookFeatureRepository _featureRepository;
@@ -42,9 +41,9 @@ namespace GrowthBook
         private readonly Context _context;
         private JObject _previousAttributes;
         private IDictionary<string, int> _previousForcedVariations;
-        private readonly List<Action<Experiment, ExperimentResult>> _subscribers 
+        private readonly List<Action<Experiment, ExperimentResult>> _subscribers
             = new List<Action<Experiment, ExperimentResult>>();
-        private readonly List<Func<Experiment, ExperimentResult, Task>> _asyncSubscribers 
+        private readonly List<Func<Experiment, ExperimentResult, Task>> _asyncSubscribers
             = new List<Func<Experiment, ExperimentResult, Task>>();
 
         /// <summary>
@@ -67,7 +66,6 @@ namespace GrowthBook
             _trackingCallback = context.TrackingCallback;
             _assigned = new Dictionary<string, ExperimentAssignment>();
             _tracked = new ConcurrentDictionary<string, byte>();
-            _subscriptions = new List<Action<Experiment, ExperimentResult>>();
             _stickyBucketService = context.StickyBucketService;
             _stickyBucketAssignmentDocs = context.StickyBucketAssignmentDocs ?? new Dictionary<string, StickyAssignmentsDocument>();
             _savedGroups = context.SavedGroups;
@@ -175,7 +173,8 @@ namespace GrowthBook
                     _trackingCallback = null;
                     _assigned.Clear();
                     _tracked.Clear();
-                    _subscriptions.Clear();
+                    _subscribers.Clear();
+                    _asyncSubscribers.Clear();
                     _featureRepository.Cancel();
 
                     if (_ownsLoggerFactory && _loggerFactory is IDisposable disposableFactory)
@@ -399,7 +398,7 @@ namespace GrowthBook
             if (alwaysLoadFeatures)
             {
                 // Fire-and-wait carefully to avoid deadlocks.
----                LoadFeatures().GetAwaiter().GetResult();
+                LoadFeatures().GetAwaiter().GetResult();
             }
 
             var result = EvaluateFeature(key);
@@ -421,13 +420,6 @@ namespace GrowthBook
         public IDictionary<string, ExperimentAssignment> GetAllResults()
         {
             return _assigned;
-        }
-
-        /// <inheritdoc />
-        public Action Subscribe(Action<Experiment, ExperimentResult> callback)
-        {
-            _subscriptions.Add(callback);
-            return () => _subscriptions.Remove(callback);
         }
 
         /// <inheritdoc />
@@ -721,17 +713,7 @@ namespace GrowthBook
             // Fire subscription callbacks if needed
             if (shouldFireCallbacks)
             {
-                foreach (Action<Experiment, ExperimentResult> callback in _subscriptions)
-                {
-                    try
-                    {
-                        callback?.Invoke(experiment, result);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, $"Encountered exception during subscription callback for experiment with key '{experiment.Key}'");
-                    }
-                }
+                NotifySubscribers(experiment, result);
             }
         }
 
@@ -1129,7 +1111,7 @@ namespace GrowthBook
                 }
             }
         }
-        
+
          /// <summary>
         /// Validates that remote evaluation configuration is correct.
         /// </summary>
@@ -1218,6 +1200,41 @@ namespace GrowthBook
                 ForcedVariations = ForcedVariations,
                 Url = Url
             };
+        }
+
+        /// <summary>
+        /// Notifies all synchronous and asynchronous subscribers about a feature or experiment evaluation result.
+        /// </summary>
+        /// <param name="experiment">The experiment that was evaluated (null if feature evaluation).</param>
+        /// <param name="result">The result of the evaluation.</param>
+        private void NotifySubscribers(Experiment experiment, ExperimentResult result)
+        {
+            foreach (var subscriber in _subscribers)
+            {
+                try
+                {
+                    subscriber(experiment, result);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Encountered unhandled exception in synchronous subscriber.");
+                }
+            }
+
+            foreach (var asyncSubscriber in _asyncSubscribers)
+            {
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await asyncSubscriber(experiment, result).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Encountered unhandled exception in asynchronous subscriber.");
+                    }
+                });
+            }
         }
     }
 }

--- a/GrowthBook/IGrowthBook.cs
+++ b/GrowthBook/IGrowthBook.cs
@@ -31,7 +31,7 @@ namespace GrowthBook
         /// <param name="key">The feature key.</param>
         /// <param name="cancellationToken">Optional cancellation token.</param>
         /// <returns>A task that resolves to <c>true</c> if the feature is on; otherwise, <c>false</c>.</returns>
-        Task<bool> IsOnAsync(string key, CancellationToken cancellationToken = default);
+        Task<bool> IsOnAsync(string key, CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// Asynchronously checks whether a feature is off (disabled) for the current context.
@@ -39,7 +39,7 @@ namespace GrowthBook
         /// <param name="key">The feature key.</param>
         /// <param name="cancellationToken">Optional cancellation token.</param>
         /// <returns>A task that resolves to <c>true</c> if the feature is off; otherwise, <c>false</c>.</returns>
-        Task<bool> IsOffAsync(string key, CancellationToken cancellationToken = default);
+        Task<bool> IsOffAsync(string key, CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// Subscribes a synchronous callback to feature evaluations.
@@ -86,14 +86,6 @@ namespace GrowthBook
         /// </summary>
         /// <returns></returns>
         IDictionary<string, ExperimentAssignment> GetAllResults();
-
-        /// <summary>
-        /// Subscribes to a GrowthBook instance to be alerted every time GrowthBook.run is called.
-        /// This is different from the tracking callback since it also fires when a user is not included in an experiment.
-        /// </summary>
-        /// <param name="callback">The callback to trigger when GrowthBook.run is called.</param>
-        /// <returns>An action callback that can be used to unsubscribe.</returns>
-        Action Subscribe(Action<Experiment, ExperimentResult> callback);
 
         /// <summary>
         /// Evaluates a feature and returns a feature result.

--- a/GrowthBook/Utilities/ExperimentUtilities.cs
+++ b/GrowthBook/Utilities/ExperimentUtilities.cs
@@ -313,7 +313,7 @@ namespace GrowthBook.Utilities
 
             if (experiment.MinBucketVersion > 0)
             {
-                for(var i = 0; i <= experiment.MinBucketVersion; i++)
+                for(var i = 0; i < experiment.MinBucketVersion; i++)
                 {
                     var blockedKey = GetStickyBucketExperimentKey(experiment.Key, i);
 
@@ -330,7 +330,7 @@ namespace GrowthBook.Utilities
             }
 
             var variationIndex = FindVariationIndex(meta, variationKey);
-                        
+
             return new StickyBucketVariation(variationIndex, isVersionBlocked: false);
         }
 


### PR DESCRIPTION
Fixed bug with minBucketVersion doesn't allow bucketVersion of the same number through