### PR TITLE
feat: add case-insensitive operators to condition evaluator

### DIFF
--- a/GrowthBook.Tests/CustomTests/SecurityConditionTests.cs
+++ b/GrowthBook.Tests/CustomTests/SecurityConditionTests.cs
@@ -159,15 +159,15 @@ namespace GrowthBook.Tests.CustomTests
         }
 
         [Fact]
-        public void SecurityTest_AllComparisonOperators_WithNull_ShouldReturnFalse()
+        public void SecurityTest_NullOrMissingAttribute_DoesNotSatisfyOutOfRangeThresholds()
         {
             // Test all comparison operators with null values
             var conditions = new[]
             {
                 @"{ ""value"": { ""$gt"": 10 } }",
                 @"{ ""value"": { ""$gte"": 10 } }",
-                @"{ ""value"": { ""$lt"": 10 } }",
-                @"{ ""value"": { ""$lte"": 10 } }"
+                @"{ ""value"": { ""$lt"": -5 } }",
+                @"{ ""value"": { ""$lte"": -5 } }"
             };
 
             var nullAttributes = JObject.Parse(@"{ ""value"": null }");

--- a/GrowthBook.Tests/Json/standard-cases.json
+++ b/GrowthBook.Tests/Json/standard-cases.json
@@ -1,5 +1,5 @@
 {
-    "specVersion": "0.7.0",
+    "specVersion": "0.7.1",
     "evalCondition": [
         [
             "$not - pass",
@@ -102,7 +102,7 @@
                 ]
             },
             {
-                "$groups": [ "a", "b", "c", "d" ]
+                "$groups": ["a", "b", "c", "d"]
             },
             true
         ],
@@ -151,7 +151,7 @@
                 ]
             },
             {
-                "$groups": [ "a", "b", "c", "d" ]
+                "$groups": ["a", "b", "c", "d"]
             },
             false
         ],
@@ -389,7 +389,7 @@
             "$in - pass",
             {
                 "num": {
-                    "$in": [ 1, 2, 3 ]
+                    "$in": [1, 2, 3]
                 }
             },
             {
@@ -401,7 +401,7 @@
             "$in - fail",
             {
                 "num": {
-                    "$in": [ 1, 2, 3 ]
+                    "$in": [1, 2, 3]
                 }
             },
             {
@@ -425,11 +425,11 @@
             "$in - array pass 1",
             {
                 "tags": {
-                    "$in": [ "a", "b" ]
+                    "$in": ["a", "b"]
                 }
             },
             {
-                "tags": [ "d", "e", "a" ]
+                "tags": ["d", "e", "a"]
             },
             true
         ],
@@ -437,11 +437,11 @@
             "$in - array pass 2",
             {
                 "tags": {
-                    "$in": [ "a", "b" ]
+                    "$in": ["a", "b"]
                 }
             },
             {
-                "tags": [ "d", "b", "f" ]
+                "tags": ["d", "b", "f"]
             },
             true
         ],
@@ -449,11 +449,11 @@
             "$in - array pass 3",
             {
                 "tags": {
-                    "$in": [ "a", "b" ]
+                    "$in": ["a", "b"]
                 }
             },
             {
-                "tags": [ "d", "b", "a" ]
+                "tags": ["d", "b", "a"]
             },
             true
         ],
@@ -461,11 +461,11 @@
             "$in - array fail 1",
             {
                 "tags": {
-                    "$in": [ "a", "b" ]
+                    "$in": ["a", "b"]
                 }
             },
             {
-                "tags": [ "d", "e", "f" ]
+                "tags": ["d", "e", "f"]
             },
             false
         ],
@@ -473,7 +473,7 @@
             "$in - array fail 2",
             {
                 "tags": {
-                    "$in": [ "a", "b" ]
+                    "$in": ["a", "b"]
                 }
             },
             {
@@ -482,10 +482,22 @@
             false
         ],
         [
+            "$in - fail (case sensitive mismatch)",
+            {
+                "country": {
+                    "$in": ["us", "uk"]
+                }
+            },
+            {
+                "country": "US"
+            },
+            false
+        ],
+        [
             "$nin - pass",
             {
                 "num": {
-                    "$nin": [ 1, 2, 3 ]
+                    "$nin": [1, 2, 3]
                 }
             },
             {
@@ -497,7 +509,7 @@
             "$nin - fail",
             {
                 "num": {
-                    "$nin": [ 1, 2, 3 ]
+                    "$nin": [1, 2, 3]
                 }
             },
             {
@@ -521,11 +533,11 @@
             "$nin - array fail 1",
             {
                 "tags": {
-                    "$nin": [ "a", "b" ]
+                    "$nin": ["a", "b"]
                 }
             },
             {
-                "tags": [ "d", "e", "a" ]
+                "tags": ["d", "e", "a"]
             },
             false
         ],
@@ -533,11 +545,11 @@
             "$nin - array fail 2",
             {
                 "tags": {
-                    "$nin": [ "a", "b" ]
+                    "$nin": ["a", "b"]
                 }
             },
             {
-                "tags": [ "d", "b", "f" ]
+                "tags": ["d", "b", "f"]
             },
             false
         ],
@@ -545,11 +557,11 @@
             "$nin - array fail 3",
             {
                 "tags": {
-                    "$nin": [ "a", "b" ]
+                    "$nin": ["a", "b"]
                 }
             },
             {
-                "tags": [ "d", "b", "a" ]
+                "tags": ["d", "b", "a"]
             },
             false
         ],
@@ -557,11 +569,11 @@
             "$nin - array pass 1",
             {
                 "tags": {
-                    "$nin": [ "a", "b" ]
+                    "$nin": ["a", "b"]
                 }
             },
             {
-                "tags": [ "d", "e", "f" ]
+                "tags": ["d", "e", "f"]
             },
             true
         ],
@@ -569,13 +581,205 @@
             "$nin - array pass 2",
             {
                 "tags": {
-                    "$nin": [ "a", "b" ]
+                    "$nin": ["a", "b"]
                 }
             },
             {
                 "tags": []
             },
             true
+        ],
+        [
+            "$nin - pass (case sensitive mismatch)",
+            {
+                "country": {
+                    "$nin": ["us", "uk"]
+                }
+            },
+            {
+                "country": "US"
+            },
+            true
+        ],
+        [
+            "$ini - pass (case insensitive match)",
+            {
+                "country": {
+                    "$ini": ["us", "uk"]
+                }
+            },
+            {
+                "country": "US"
+            },
+            true
+        ],
+        [
+            "$ini - pass (uppercase pattern, lowercase value)",
+            {
+                "country": {
+                    "$ini": ["US", "UK"]
+                }
+            },
+            {
+                "country": "us"
+            },
+            true
+        ],
+        [
+            "$ini - pass (mixed case)",
+            {
+                "country": {
+                    "$ini": ["Us", "Uk"]
+                }
+            },
+            {
+                "country": "US"
+            },
+            true
+        ],
+        [
+            "$ini - fail (no match)",
+            {
+                "country": {
+                    "$ini": ["us", "uk"]
+                }
+            },
+            {
+                "country": "CA"
+            },
+            false
+        ],
+        [
+            "$ini - array pass 1",
+            {
+                "tags": {
+                    "$ini": ["a", "b"]
+                }
+            },
+            {
+                "tags": ["d", "e", "A"]
+            },
+            true
+        ],
+        [
+            "$ini - array pass 2",
+            {
+                "tags": {
+                    "$ini": ["A", "B"]
+                }
+            },
+            {
+                "tags": ["d", "b", "f"]
+            },
+            true
+        ],
+        [
+            "$ini - array fail",
+            {
+                "tags": {
+                    "$ini": ["a", "b"]
+                }
+            },
+            {
+                "tags": ["d", "e", "f"]
+            },
+            false
+        ],
+        [
+            "$ini - not array",
+            {
+                "num": {
+                    "$ini": 1
+                }
+            },
+            {
+                "num": 1
+            },
+            false
+        ],
+        [
+            "$nini - pass (case insensitive match)",
+            {
+                "country": {
+                    "$nini": ["us", "uk"]
+                }
+            },
+            {
+                "country": "CA"
+            },
+            true
+        ],
+        [
+            "$nini - fail (case insensitive match)",
+            {
+                "country": {
+                    "$nini": ["us", "uk"]
+                }
+            },
+            {
+                "country": "US"
+            },
+            false
+        ],
+        [
+            "$nini - fail (uppercase pattern, lowercase value)",
+            {
+                "country": {
+                    "$nini": ["US", "UK"]
+                }
+            },
+            {
+                "country": "us"
+            },
+            false
+        ],
+        [
+            "$nini - array pass",
+            {
+                "tags": {
+                    "$nini": ["a", "b"]
+                }
+            },
+            {
+                "tags": ["d", "e", "f"]
+            },
+            true
+        ],
+        [
+            "$nini - array fail 1",
+            {
+                "tags": {
+                    "$nini": ["a", "b"]
+                }
+            },
+            {
+                "tags": ["d", "e", "A"]
+            },
+            false
+        ],
+        [
+            "$nini - array fail 2",
+            {
+                "tags": {
+                    "$nini": ["A", "B"]
+                }
+            },
+            {
+                "tags": ["d", "b", "f"]
+            },
+            false
+        ],
+        [
+            "$nini - not array",
+            {
+                "num": {
+                    "$nini": 1
+                }
+            },
+            {
+                "num": 1
+            },
+            false
         ],
         [
             "$elemMatch - pass - flat arrays",
@@ -587,7 +791,7 @@
                 }
             },
             {
-                "nums": [ 0, 5, -20, 15 ]
+                "nums": [0, 5, -20, 15]
             },
             true
         ],
@@ -601,7 +805,7 @@
                 }
             },
             {
-                "nums": [ 0, 5, -20, 8 ]
+                "nums": [0, 5, -20, 8]
             },
             false
         ],
@@ -609,7 +813,7 @@
             "missing attribute - fail",
             {
                 "pets.dog.name": {
-                    "$in": [ "fido" ]
+                    "$in": ["fido"]
                 }
             },
             {
@@ -629,118 +833,6 @@
                 }
             },
             {},
-            false
-        ],
-        [
-            "null attribute with $gt - security test",
-            {
-                "userLevel": {
-                    "$gte": 5
-                }
-            },
-            {
-                "userLevel": null
-            },
-            false
-        ],
-        [
-            "missing attribute with $gte - age verification test",
-            {
-                "age": {
-                    "$gte": 18
-                }
-            },
-            {},
-            false
-        ],
-        [
-            "null attribute with $gt - credit score test",
-            {
-                "creditScore": {
-                    "$gt": 600
-                }
-            },
-            {
-                "creditScore": null
-            },
-            false
-        ],
-        [
-            "missing attribute with $gte - resource allocation test",
-            {
-                "availableMemory": {
-                    "$gte": 1024
-                }
-            },
-            {},
-            false
-        ],
-        [
-            "null attribute with $gt - data quality test",
-            {
-                "dataQuality": {
-                    "$gt": 0.8
-                }
-            },
-            {
-                "dataQuality": null
-            },
-            false
-        ],
-        [
-            "missing attribute with $lt - upper bound test",
-            {
-                "temperature": {
-                    "$lt": 100
-                }
-            },
-            {},
-            false
-        ],
-        [
-            "null attribute with $lte - lower bound test",
-            {
-                "pressure": {
-                    "$lte": 50
-                }
-            },
-            {
-                "pressure": null
-            },
-            false
-        ],
-        [
-            "mixed conditions with missing attributes",
-            {
-                "$and": [
-                    {
-                        "age": {
-                            "$gte": 18
-                        }
-                    },
-                    {
-                        "creditScore": {
-                            "$gt": 600
-                        }
-                    }
-                ]
-            },
-            {
-                "age": 25
-            },
-            false
-        ],
-        [
-            "comparison with existing valid attribute",
-            {
-                "age": {
-                    "$gte": 18,
-                    "$lt": 65
-                }
-            },
-            {
-                "age": 30
-            },
             true
         ],
         [
@@ -862,6 +954,54 @@
             {
                 "userAgent": {
                     "$regex": "(Mobile|Tablet)"
+                }
+            },
+            {
+                "userAgent": "Chrome Desktop Browser"
+            },
+            false
+        ],
+        [
+            "$regex - fail (case sensitive mismatch)",
+            {
+                "userAgent": {
+                    "$regex": "(mobile|tablet)"
+                }
+            },
+            {
+                "userAgent": "Android Mobile Browser"
+            },
+            false
+        ],
+        [
+            "$regexi - pass (case insensitive match)",
+            {
+                "userAgent": {
+                    "$regexi": "(mobile|tablet)"
+                }
+            },
+            {
+                "userAgent": "Android Mobile Browser"
+            },
+            true
+        ],
+        [
+            "$regexi - pass (uppercase pattern, lowercase value)",
+            {
+                "userAgent": {
+                    "$regexi": "(MOBILE|TABLET)"
+                }
+            },
+            {
+                "userAgent": "android mobile browser"
+            },
+            true
+        ],
+        [
+            "$regexi - fail",
+            {
+                "userAgent": {
+                    "$regexi": "(mobile|tablet)"
                 }
             },
             {
@@ -1175,7 +1315,7 @@
                 }
             },
             {
-                "a": [ 1, 2 ]
+                "a": [1, 2]
             },
             true
         ],
@@ -1243,7 +1383,7 @@
                 "tags": { "$size": 0 }
             },
             {
-                "tags": [ 10 ]
+                "tags": [10]
             },
             false
         ],
@@ -1255,7 +1395,7 @@
                 }
             },
             {
-                "tags": [ "a", "b", "c" ]
+                "tags": ["a", "b", "c"]
             },
             true
         ],
@@ -1267,7 +1407,7 @@
                 }
             },
             {
-                "tags": [ "a", "b" ]
+                "tags": ["a", "b"]
             },
             false
         ],
@@ -1279,7 +1419,7 @@
                 }
             },
             {
-                "tags": [ "a", "b", "c", "d" ]
+                "tags": ["a", "b", "c", "d"]
             },
             false
         ],
@@ -1305,7 +1445,7 @@
                 }
             },
             {
-                "tags": [ 0, 1, 2 ]
+                "tags": [0, 1, 2]
             },
             true
         ],
@@ -1319,7 +1459,7 @@
                 }
             },
             {
-                "tags": [ 0, 1 ]
+                "tags": [0, 1]
             },
             false
         ],
@@ -1333,7 +1473,7 @@
                 }
             },
             {
-                "tags": [ 0 ]
+                "tags": [0]
             },
             false
         ],
@@ -1347,7 +1487,7 @@
                 }
             },
             {
-                "tags": [ "foo", "bar", "baz" ]
+                "tags": ["foo", "bar", "baz"]
             },
             true
         ],
@@ -1361,7 +1501,7 @@
                 }
             },
             {
-                "tags": [ "foo", "baz" ]
+                "tags": ["foo", "baz"]
             },
             false
         ],
@@ -1370,12 +1510,12 @@
             {
                 "tags": {
                     "$elemMatch": {
-                        "$in": [ "a", "b" ]
+                        "$in": ["a", "b"]
                     }
                 }
             },
             {
-                "tags": [ "d", "e", "b" ]
+                "tags": ["d", "e", "b"]
             },
             true
         ],
@@ -1384,12 +1524,12 @@
             {
                 "tags": {
                     "$elemMatch": {
-                        "$in": [ "a", "b" ]
+                        "$in": ["a", "b"]
                     }
                 }
             },
             {
-                "tags": [ "d", "e", "f" ]
+                "tags": ["d", "e", "f"]
             },
             false
         ],
@@ -1405,7 +1545,7 @@
                 }
             },
             {
-                "tags": [ "foo", "baz" ]
+                "tags": ["foo", "baz"]
             },
             true
         ],
@@ -1421,7 +1561,7 @@
                 }
             },
             {
-                "tags": [ "foo", "bar", "baz" ]
+                "tags": ["foo", "bar", "baz"]
             },
             false
         ],
@@ -1522,11 +1662,11 @@
             "$all - pass",
             {
                 "tags": {
-                    "$all": [ "one", "three" ]
+                    "$all": ["one", "three"]
                 }
             },
             {
-                "tags": [ "one", "two", "three" ]
+                "tags": ["one", "two", "three"]
             },
             true
         ],
@@ -1534,11 +1674,11 @@
             "$all - fail",
             {
                 "tags": {
-                    "$all": [ "one", "three" ]
+                    "$all": ["one", "three"]
                 }
             },
             {
-                "tags": [ "one", "two", "four" ]
+                "tags": ["one", "two", "four"]
             },
             false
         ],
@@ -1546,7 +1686,79 @@
             "$all - fail not array",
             {
                 "tags": {
-                    "$all": [ "one", "three" ]
+                    "$all": ["one", "three"]
+                }
+            },
+            {
+                "tags": "hello"
+            },
+            false
+        ],
+        [
+            "$all - fail (case sensitive mismatch)",
+            {
+                "tags": {
+                    "$all": ["one", "three"]
+                }
+            },
+            {
+                "tags": ["ONE", "two", "THREE"]
+            },
+            false
+        ],
+        [
+            "$alli - pass (case insensitive match)",
+            {
+                "tags": {
+                    "$alli": ["one", "three"]
+                }
+            },
+            {
+                "tags": ["ONE", "two", "THREE"]
+            },
+            true
+        ],
+        [
+            "$alli - pass (uppercase pattern, lowercase value)",
+            {
+                "tags": {
+                    "$alli": ["ONE", "THREE"]
+                }
+            },
+            {
+                "tags": ["one", "two", "three"]
+            },
+            true
+        ],
+        [
+            "$alli - pass (mixed case)",
+            {
+                "tags": {
+                    "$alli": ["One", "Three"]
+                }
+            },
+            {
+                "tags": ["ONE", "two", "three"]
+            },
+            true
+        ],
+        [
+            "$alli - fail (case insensitive, missing value)",
+            {
+                "tags": {
+                    "$alli": ["one", "three"]
+                }
+            },
+            {
+                "tags": ["ONE", "two", "four"]
+            },
+            false
+        ],
+        [
+            "$alli - fail not array",
+            {
+                "tags": {
+                    "$alli": ["one", "three"]
                 }
             },
             {
@@ -1637,47 +1849,47 @@
         [
             "equals array - pass",
             {
-                "tags": [ "hello", "world" ]
+                "tags": ["hello", "world"]
             },
             {
-                "tags": [ "hello", "world" ]
+                "tags": ["hello", "world"]
             },
             true
         ],
         [
             "equals array - fail order",
             {
-                "tags": [ "hello", "world" ]
+                "tags": ["hello", "world"]
             },
             {
-                "tags": [ "world", "hello" ]
+                "tags": ["world", "hello"]
             },
             false
         ],
         [
             "equals array - fail missing item",
             {
-                "tags": [ "hello", "world" ]
+                "tags": ["hello", "world"]
             },
             {
-                "tags": [ "hello" ]
+                "tags": ["hello"]
             },
             false
         ],
         [
             "equals array - fail extra item",
             {
-                "tags": [ "hello", "world" ]
+                "tags": ["hello", "world"]
             },
             {
-                "tags": [ "hello", "world", "foo" ]
+                "tags": ["hello", "world", "foo"]
             },
             false
         ],
         [
             "equals array - fail type mismatch",
             {
-                "tags": [ "hello", "world" ]
+                "tags": ["hello", "world"]
             },
             {
                 "tags": "hello world"
@@ -1783,6 +1995,32 @@
             {
                 "userId": ""
             },
+            false
+        ],
+        [
+            "null condition - false attribute",
+            {
+                "userId": null
+            },
+            {
+                "userId": false
+            },
+            false
+        ],
+        [
+            "false condition - missing attribute",
+            {
+                "userId": false
+            },
+            {},
+            false
+        ],
+        [
+            "false strict condition - missing attribute",
+            {
+                "userId": { "$eq": false }
+            },
+            {},
             false
         ],
         [
@@ -2891,10 +3129,7 @@
         [
             "$or pass but second condition fail",
             {
-                "$or": [
-                    { "foo": 1 },
-                    { "bar": 1 }
-                ],
+                "$or": [{ "foo": 1 }, { "bar": 1 }],
                 "baz": 2
             },
             {
@@ -2907,10 +3142,7 @@
         [
             "$or and second condition both pass",
             {
-                "$or": [
-                    { "foo": 1 },
-                    { "bar": 1 }
-                ],
+                "$or": [{ "foo": 1 }, { "bar": 1 }],
                 "baz": 2
             },
             {
@@ -2923,14 +3155,8 @@
         [
             "$and condition pass but $or fail",
             {
-                "$and": [
-                    { "foo": 1 },
-                    { "bar": 1 }
-                ],
-                "$or": [
-                    { "baz": 1 },
-                    { "empty": 1 }
-                ]
+                "$and": [{ "foo": 1 }, { "bar": 1 }],
+                "$or": [{ "baz": 1 }, { "empty": 1 }]
             },
             {
                 "foo": 1,
@@ -2942,14 +3168,8 @@
         [
             "$and and $or both pass",
             {
-                "$and": [
-                    { "foo": 1 },
-                    { "bar": 1 }
-                ],
-                "$or": [
-                    { "baz": 1 },
-                    { "empty": 1 }
-                ]
+                "$and": [{ "foo": 1 }, { "bar": 1 }],
+                "$or": [{ "baz": 1 }, { "empty": 1 }]
             },
             {
                 "foo": 1,
@@ -2966,7 +3186,7 @@
             },
             { "id": 1 },
             true,
-            { "group_id": [ 1, 2, 3 ] }
+            { "group_id": [1, 2, 3] }
         ],
         [
             "$inGroup fails for non-member of known group id",
@@ -2975,7 +3195,7 @@
             },
             { "id": 5 },
             false,
-            { "group_id": [ 1, 2, 3 ] }
+            { "group_id": [1, 2, 3] }
         ],
         [
             "$inGroup fails for unknown group id",
@@ -2984,7 +3204,7 @@
             },
             { "id": 1 },
             false,
-            { "group_id": [ 1, 2, 3 ] }
+            { "group_id": [1, 2, 3] }
         ],
         [
             "$notInGroup fails for member of known group id",
@@ -2993,7 +3213,7 @@
             },
             { "id": 1 },
             false,
-            { "group_id": [ 1, 2, 3 ] }
+            { "group_id": [1, 2, 3] }
         ],
         [
             "$notInGroup passes for non-member of known group id",
@@ -3002,7 +3222,7 @@
             },
             { "id": 5 },
             true,
-            { "group_id": [ 1, 2, 3 ] }
+            { "group_id": [1, 2, 3] }
         ],
         [
             "$notInGroup passes for unknown group id",
@@ -3011,7 +3231,7 @@
             },
             { "id": 1 },
             true,
-            { "group_id": [ 1, 2, 3 ] }
+            { "group_id": [1, 2, 3] }
         ],
         [
             "$inGroup passes for properly typed data",
@@ -3020,7 +3240,7 @@
             },
             { "id": "2" },
             true,
-            { "group_id": [ 1, "2", 3 ] }
+            { "group_id": [1, "2", 3] }
         ],
         [
             "$inGroup fails for improperly typed data",
@@ -3029,163 +3249,135 @@
             },
             { "id": "3" },
             false,
-            { "group_id": [ 1, "2", 3 ] }
+            { "group_id": [1, "2", 3] }
         ]
     ],
     "hash": [
-        [ "", "a", 1, 0.22 ],
-        [ "", "b", 1, 0.077 ],
-        [ "b", "a", 1, 0.946 ],
-        [ "ef", "d", 1, 0.652 ],
-        [ "asdf", "8952klfjas09ujk", 1, 0.549 ],
-        [ "", "123", 1, 0.011 ],
-        [ "", "___)((*\":&", 1, 0.563 ],
-        [ "seed", "a", 2, 0.0505 ],
-        [ "seed", "b", 2, 0.2696 ],
-        [ "foo", "ab", 2, 0.2575 ],
-        [ "foo", "def", 2, 0.2019 ],
-        [ "89123klj", "8952klfjas09ujkasdf", 2, 0.124 ],
-        [ "90850943850283058242805", "123", 2, 0.7516 ],
-        [ "()**(%$##$%#$#", "___)((*\":&", 2, 0.0128 ],
-        [ "abc", "def", 99, null ]
+        ["", "a", 1, 0.22],
+        ["", "b", 1, 0.077],
+        ["b", "a", 1, 0.946],
+        ["ef", "d", 1, 0.652],
+        ["asdf", "8952klfjas09ujk", 1, 0.549],
+        ["", "123", 1, 0.011],
+        ["", "___)((*\":&", 1, 0.563],
+        ["seed", "a", 2, 0.0505],
+        ["seed", "b", 2, 0.2696],
+        ["foo", "ab", 2, 0.2575],
+        ["foo", "def", 2, 0.2019],
+        ["89123klj", "8952klfjas09ujkasdf", 2, 0.124],
+        ["90850943850283058242805", "123", 2, 0.7516],
+        ["()**(%$##$%#$#", "___)((*\":&", 2, 0.0128],
+        ["abc", "def", 99, null]
     ],
     "getBucketRange": [
         [
             "normal 50/50",
-            [ 2, 1, null ],
+            [2, 1, null],
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [0, 0.5],
+                [0.5, 1]
             ]
         ],
         [
             "reduced coverage",
-            [ 2, 0.5, null ],
+            [2, 0.5, null],
             [
-                [ 0, 0.25 ],
-                [ 0.5, 0.75 ]
+                [0, 0.25],
+                [0.5, 0.75]
             ]
         ],
         [
             "zero coverage",
-            [ 2, 0, null ],
+            [2, 0, null],
             [
-                [ 0, 0 ],
-                [ 0.5, 0.5 ]
+                [0, 0],
+                [0.5, 0.5]
             ]
         ],
         [
             "4 variations",
-            [ 4, 1, null ],
+            [4, 1, null],
             [
-                [ 0, 0.25 ],
-                [ 0.25, 0.5 ],
-                [ 0.5, 0.75 ],
-                [ 0.75, 1 ]
+                [0, 0.25],
+                [0.25, 0.5],
+                [0.5, 0.75],
+                [0.75, 1]
             ]
         ],
         [
             "uneven weights",
+            [2, 1, [0.4, 0.6]],
             [
-                2,
-                1,
-                [ 0.4, 0.6 ]
-            ],
-            [
-                [ 0, 0.4 ],
-                [ 0.4, 1 ]
+                [0, 0.4],
+                [0.4, 1]
             ]
         ],
         [
             "uneven weights, 3 variations",
+            [3, 1, [0.2, 0.3, 0.5]],
             [
-                3,
-                1,
-                [ 0.2, 0.3, 0.5 ]
-            ],
-            [
-                [ 0, 0.2 ],
-                [ 0.2, 0.5 ],
-                [ 0.5, 1 ]
+                [0, 0.2],
+                [0.2, 0.5],
+                [0.5, 1]
             ]
         ],
         [
             "uneven weights, reduced coverage, 3 variations",
+            [3, 0.2, [0.2, 0.3, 0.5]],
             [
-                3,
-                0.2,
-                [ 0.2, 0.3, 0.5 ]
-            ],
-            [
-                [ 0, 0.04 ],
-                [ 0.2, 0.26 ],
-                [ 0.5, 0.6 ]
+                [0, 0.04],
+                [0.2, 0.26],
+                [0.5, 0.6]
             ]
         ],
         [
             "negative coverage",
-            [ 2, -0.2, null ],
+            [2, -0.2, null],
             [
-                [ 0, 0 ],
-                [ 0.5, 0.5 ]
+                [0, 0],
+                [0.5, 0.5]
             ]
         ],
         [
             "coverage above 1",
-            [ 2, 1.5, null ],
+            [2, 1.5, null],
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [0, 0.5],
+                [0.5, 1]
             ]
         ],
         [
             "weights sum below 1",
+            [2, 1, [0.4, 0.1]],
             [
-                2,
-                1,
-                [ 0.4, 0.1 ]
-            ],
-            [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [0, 0.5],
+                [0.5, 1]
             ]
         ],
         [
             "weights sum above 1",
+            [2, 1, [0.7, 0.6]],
             [
-                2,
-                1,
-                [ 0.7, 0.6 ]
-            ],
-            [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [0, 0.5],
+                [0.5, 1]
             ]
         ],
         [
             "weights.length not equal to num variations",
+            [4, 1, [0.4, 0.4, 0.2]],
             [
-                4,
-                1,
-                [ 0.4, 0.4, 0.2 ]
-            ],
-            [
-                [ 0, 0.25 ],
-                [ 0.25, 0.5 ],
-                [ 0.5, 0.75 ],
-                [ 0.75, 1 ]
+                [0, 0.25],
+                [0.25, 0.5],
+                [0.5, 0.75],
+                [0.75, 1]
             ]
         ],
         [
             "weights sum almost equals 1",
+            [2, 1, [0.4, 0.5999]],
             [
-                2,
-                1,
-                [ 0.4, 0.5999 ]
-            ],
-            [
-                [ 0, 0.4 ],
-                [ 0.4, 0.9999 ]
+                [0, 0.4],
+                [0.4, 0.9999]
             ]
         ]
     ],
@@ -3198,7 +3390,8 @@
                 "value": null,
                 "on": false,
                 "off": true,
-                "source": "unknownFeature"
+                "source": "unknownFeature",
+                "ruleId": ""
             }
         ],
         [
@@ -3209,7 +3402,8 @@
                 "value": null,
                 "on": false,
                 "off": true,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -3220,7 +3414,8 @@
                 "value": 1,
                 "on": true,
                 "off": false,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -3231,7 +3426,8 @@
                 "value": "yes",
                 "on": true,
                 "off": false,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -3253,7 +3449,32 @@
                 "value": 1,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
+            }
+        ],
+        [
+            "force rule with rule id",
+            {
+                "features": {
+                    "feature": {
+                        "defaultValue": 2,
+                        "rules": [
+                            {
+                                "id": "a",
+                                "force": 1
+                            }
+                        ]
+                    }
+                }
+            },
+            "feature",
+            {
+                "value": 1,
+                "on": true,
+                "off": false,
+                "source": "force",
+                "ruleId": "a"
             }
         ],
         [
@@ -3275,7 +3496,8 @@
                 "value": false,
                 "on": false,
                 "off": true,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -3301,7 +3523,8 @@
                 "value": 1,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -3327,7 +3550,8 @@
                 "value": 1,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -3341,6 +3565,7 @@
                         "defaultValue": 2,
                         "rules": [
                             {
+                                "id": "a",
                                 "force": 1,
                                 "coverage": 0.5
                             }
@@ -3353,7 +3578,8 @@
                 "value": 2,
                 "on": true,
                 "off": false,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -3377,7 +3603,8 @@
                 "value": 2,
                 "on": true,
                 "off": false,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -3404,7 +3631,8 @@
                 "value": 0,
                 "on": false,
                 "off": true,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -3421,7 +3649,7 @@
                             {
                                 "force": 1,
                                 "condition": {
-                                    "country": { "$in": [ "US", "CA" ] },
+                                    "country": { "$in": ["US", "CA"] },
                                     "browser": "firefox"
                                 }
                             }
@@ -3434,7 +3662,8 @@
                 "value": 1,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -3451,7 +3680,7 @@
                             {
                                 "force": 1,
                                 "condition": {
-                                    "country": { "$in": [ "US", "CA" ] },
+                                    "country": { "$in": ["US", "CA"] },
                                     "browser": "firefox"
                                 }
                             }
@@ -3464,7 +3693,8 @@
                 "value": 2,
                 "on": true,
                 "off": false,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -3491,7 +3721,8 @@
                 "value": 2,
                 "on": true,
                 "off": false,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -3499,7 +3730,7 @@
             {
                 "features": {
                     "feature": {
-                        "rules": [ {} ]
+                        "rules": [{}]
                     }
                 }
             },
@@ -3508,7 +3739,8 @@
                 "value": null,
                 "on": false,
                 "off": true,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -3521,7 +3753,7 @@
                     "feature": {
                         "rules": [
                             {
-                                "variations": [ "a", "b", "c" ]
+                                "variations": ["a", "b", "c"]
                             }
                         ]
                     }
@@ -3534,7 +3766,7 @@
                 "off": false,
                 "experiment": {
                     "key": "feature",
-                    "variations": [ "a", "b", "c" ]
+                    "variations": ["a", "b", "c"]
                 },
                 "experimentResult": {
                     "featureId": "feature",
@@ -3548,7 +3780,8 @@
                     "key": "2",
                     "stickyBucketUsed": false
                 },
-                "source": "experiment"
+                "source": "experiment",
+                "ruleId": ""
             }
         ],
         [
@@ -3561,7 +3794,8 @@
                     "feature": {
                         "rules": [
                             {
-                                "variations": [ "a", "b", "c" ]
+                                "id": "id",
+                                "variations": ["a", "b", "c"]
                             }
                         ]
                     }
@@ -3574,7 +3808,7 @@
                 "off": false,
                 "experiment": {
                     "key": "feature",
-                    "variations": [ "a", "b", "c" ]
+                    "variations": ["a", "b", "c"]
                 },
                 "experimentResult": {
                     "featureId": "feature",
@@ -3588,7 +3822,8 @@
                     "key": "0",
                     "stickyBucketUsed": false
                 },
-                "source": "experiment"
+                "source": "experiment",
+                "ruleId": "id"
             }
         ],
         [
@@ -3601,7 +3836,7 @@
                     "feature": {
                         "rules": [
                             {
-                                "variations": [ "a", "b", "c" ]
+                                "variations": ["a", "b", "c"]
                             }
                         ]
                     }
@@ -3614,7 +3849,7 @@
                 "off": false,
                 "experiment": {
                     "key": "feature",
-                    "variations": [ "a", "b", "c" ]
+                    "variations": ["a", "b", "c"]
                 },
                 "experimentResult": {
                     "featureId": "feature",
@@ -3628,7 +3863,8 @@
                     "key": "1",
                     "stickyBucketUsed": false
                 },
-                "source": "experiment"
+                "source": "experiment",
+                "ruleId": ""
             }
         ],
         [
@@ -3649,8 +3885,8 @@
                                 "name": "Test",
                                 "phase": "1",
                                 "ranges": [
-                                    [ 0, 0.1 ],
-                                    [ 0.1, 1.0 ]
+                                    [0, 0.1],
+                                    [0.1, 1.0]
                                 ],
                                 "meta": [
                                     {
@@ -3666,14 +3902,15 @@
                                     {
                                         "attribute": "anonId",
                                         "seed": "pricing",
-                                        "ranges": [ [ 0, 1 ] ]
+                                        "ranges": [[0, 1]]
                                     }
                                 ],
-                                "namespace": [ "pricing", 0, 1 ],
+                                "namespace": ["pricing", 0, 1],
                                 "key": "hello",
-                                "variations": [ true, false ],
-                                "weights": [ 0.1, 0.9 ],
-                                "condition": { "premium": true }
+                                "variations": [true, false],
+                                "weights": [0.1, 0.9],
+                                "condition": { "premium": true },
+                                "foo": "bar"
                             }
                         ]
                     }
@@ -3688,8 +3925,8 @@
                 "experiment": {
                     "coverage": 0.99,
                     "ranges": [
-                        [ 0, 0.1 ],
-                        [ 0.1, 1.0 ]
+                        [0, 0.1],
+                        [0.1, 1.0]
                     ],
                     "meta": [
                         {
@@ -3705,7 +3942,7 @@
                         {
                             "attribute": "anonId",
                             "seed": "pricing",
-                            "ranges": [ [ 0, 1 ] ]
+                            "ranges": [[0, 1]]
                         }
                     ],
                     "name": "Test",
@@ -3713,10 +3950,10 @@
                     "seed": "feature",
                     "hashVersion": 2,
                     "hashAttribute": "anonId",
-                    "namespace": [ "pricing", 0, 1 ],
+                    "namespace": ["pricing", 0, 1],
                     "key": "hello",
-                    "variations": [ true, false ],
-                    "weights": [ 0.1, 0.9 ],
+                    "variations": [true, false],
+                    "weights": [0.1, 0.9],
                     "condition": { "premium": true }
                 },
                 "experimentResult": {
@@ -3731,7 +3968,8 @@
                     "key": "v1",
                     "name": "variation 1",
                     "stickyBucketUsed": false
-                }
+                },
+                "ruleId": ""
             }
         ],
         [
@@ -3765,7 +4003,8 @@
                 "value": 2,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -3780,13 +4019,16 @@
                         "rules": [
                             {
                                 "force": 1,
+                                "id": "1",
                                 "condition": { "browser": "chrome" }
                             },
                             {
+                                "id": "2",
                                 "force": 2,
                                 "condition": { "browser": "firefox" }
                             },
                             {
+                                "id": "3",
                                 "force": 3,
                                 "condition": { "browser": "safari" }
                             }
@@ -3799,7 +4041,8 @@
                 "value": 3,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": "3"
             }
         ],
         [
@@ -3833,7 +4076,8 @@
                 "value": 0,
                 "on": false,
                 "off": true,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -3845,7 +4089,7 @@
                         "defaultValue": 0,
                         "rules": [
                             {
-                                "variations": [ 0, 1, 2, 3 ],
+                                "variations": [0, 1, 2, 3],
                                 "coverage": 0.01
                             },
                             {
@@ -3860,7 +4104,8 @@
                 "value": 3,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -3872,8 +4117,8 @@
                         "defaultValue": 0,
                         "rules": [
                             {
-                                "variations": [ 0, 1, 2, 3 ],
-                                "namespace": [ "pricing", 0, 0.01 ]
+                                "variations": [0, 1, 2, 3],
+                                "namespace": ["pricing", 0, 0.01]
                             },
                             {
                                 "force": 3
@@ -3887,7 +4132,8 @@
                 "value": 3,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -3899,7 +4145,7 @@
                         "defaultValue": 0,
                         "rules": [
                             {
-                                "variations": [ 0, 1 ]
+                                "variations": [0, 1]
                             }
                         ]
                     }
@@ -3913,7 +4159,7 @@
                 "source": "experiment",
                 "experiment": {
                     "key": "feature",
-                    "variations": [ 0, 1 ]
+                    "variations": [0, 1]
                 },
                 "experimentResult": {
                     "featureId": "feature",
@@ -3926,7 +4172,8 @@
                     "key": "1",
                     "bucket": 0.863,
                     "stickyBucketUsed": false
-                }
+                },
+                "ruleId": ""
             }
         ],
         [
@@ -3938,7 +4185,7 @@
                         "defaultValue": 0,
                         "rules": [
                             {
-                                "variations": [ 0, 1, 2, 3 ],
+                                "variations": [0, 1, 2, 3],
                                 "hashAttribute": "company"
                             },
                             {
@@ -3953,7 +4200,8 @@
                 "value": 3,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -3968,7 +4216,7 @@
                         "defaultValue": 0,
                         "rules": [
                             {
-                                "variations": [ 0, 1, 2, 3 ]
+                                "variations": [0, 1, 2, 3]
                             },
                             {
                                 "force": 3
@@ -3985,7 +4233,7 @@
                 "source": "experiment",
                 "experiment": {
                     "key": "feature",
-                    "variations": [ 0, 1, 2, 3 ]
+                    "variations": [0, 1, 2, 3]
                 },
                 "experimentResult": {
                     "featureId": "feature",
@@ -3997,7 +4245,8 @@
                     "hashValue": "123",
                     "key": "1",
                     "stickyBucketUsed": false
-                }
+                },
+                "ruleId": ""
             }
         ],
         [
@@ -4013,7 +4262,7 @@
                             {
                                 "force": 2,
                                 "coverage": 0.01,
-                                "range": [ 0, 0.99 ]
+                                "range": [0, 0.99]
                             }
                         ]
                     }
@@ -4024,7 +4273,8 @@
                 "value": 2,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -4040,7 +4290,7 @@
                             {
                                 "force": 2,
                                 "hashVersion": 2,
-                                "range": [ 0.96, 0.97 ]
+                                "range": [0.96, 0.97]
                             }
                         ]
                     }
@@ -4051,7 +4301,8 @@
                 "value": 2,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -4066,7 +4317,7 @@
                         "rules": [
                             {
                                 "force": 2,
-                                "range": [ 0, 0.01 ]
+                                "range": [0, 0.01]
                             }
                         ]
                     }
@@ -4077,7 +4328,8 @@
                 "value": 0,
                 "on": false,
                 "off": true,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -4095,7 +4347,7 @@
                                 "filters": [
                                     {
                                         "seed": "seed",
-                                        "ranges": [ [ 0, 0.01 ] ]
+                                        "ranges": [[0, 0.01]]
                                     }
                                 ]
                             }
@@ -4108,7 +4360,8 @@
                 "value": 0,
                 "on": false,
                 "off": true,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -4123,7 +4376,7 @@
                         "rules": [
                             {
                                 "force": 2,
-                                "range": [ 0, 0.5 ],
+                                "range": [0, 0.5],
                                 "seed": "fjdslafdsa",
                                 "hashVersion": 2
                             }
@@ -4136,7 +4389,8 @@
                 "value": 2,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -4151,11 +4405,11 @@
                         "rules": [
                             {
                                 "key": "holdout",
-                                "variations": [ 1, 2 ],
+                                "variations": [1, 2],
                                 "hashVersion": 2,
                                 "ranges": [
-                                    [ 0, 0.01 ],
-                                    [ 0.01, 1.0 ]
+                                    [0, 0.01],
+                                    [0.01, 1.0]
                                 ],
                                 "meta": [
                                     {},
@@ -4166,11 +4420,11 @@
                             },
                             {
                                 "key": "experiment",
-                                "variations": [ 3, 4 ],
+                                "variations": [3, 4],
                                 "hashVersion": 2,
                                 "ranges": [
-                                    [ 0, 0.5 ],
-                                    [ 0.5, 1.0 ]
+                                    [0, 0.5],
+                                    [0.5, 1.0]
                                 ]
                             }
                         ]
@@ -4186,10 +4440,10 @@
                 "experiment": {
                     "key": "experiment",
                     "hashVersion": 2,
-                    "variations": [ 3, 4 ],
+                    "variations": [3, 4],
                     "ranges": [
-                        [ 0, 0.5 ],
-                        [ 0.5, 1.0 ]
+                        [0, 0.5],
+                        [0.5, 1.0]
                     ]
                 },
                 "experimentResult": {
@@ -4203,7 +4457,8 @@
                     "variationId": 0,
                     "bucket": 0.4413,
                     "stickyBucketUsed": false
-                }
+                },
+                "ruleId": ""
             }
         ],
         [
@@ -4219,10 +4474,10 @@
                             {
                                 "key": "holdout",
                                 "hashVersion": 2,
-                                "variations": [ 1, 2 ],
+                                "variations": [1, 2],
                                 "ranges": [
-                                    [ 0, 0.99 ],
-                                    [ 0.99, 1.0 ]
+                                    [0, 0.99],
+                                    [0.99, 1.0]
                                 ],
                                 "meta": [
                                     {},
@@ -4234,10 +4489,10 @@
                             {
                                 "key": "experiment",
                                 "hashVersion": 2,
-                                "variations": [ 3, 4 ],
+                                "variations": [3, 4],
                                 "ranges": [
-                                    [ 0, 0.5 ],
-                                    [ 0.5, 1.0 ]
+                                    [0, 0.5],
+                                    [0.5, 1.0]
                                 ]
                             }
                         ]
@@ -4253,8 +4508,8 @@
                 "experiment": {
                     "hashVersion": 2,
                     "ranges": [
-                        [ 0, 0.99 ],
-                        [ 0.99, 1.0 ]
+                        [0, 0.99],
+                        [0.99, 1.0]
                     ],
                     "meta": [
                         {},
@@ -4263,7 +4518,7 @@
                         }
                     ],
                     "key": "holdout",
-                    "variations": [ 1, 2 ]
+                    "variations": [1, 2]
                 },
                 "experimentResult": {
                     "featureId": "feature",
@@ -4276,7 +4531,8 @@
                     "variationId": 0,
                     "bucket": 0.8043,
                     "stickyBucketUsed": false
-                }
+                },
+                "ruleId": ""
             }
         ],
         [
@@ -4296,7 +4552,7 @@
                                 "force": "red"
                             },
                             {
-                                "condition": { "country": { "$in": [ "USA", "Mexico" ] } },
+                                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                                 "force": "green"
                             }
                         ]
@@ -4326,7 +4582,8 @@
                 "value": null,
                 "on": false,
                 "off": true,
-                "source": "prerequisite"
+                "source": "prerequisite",
+                "ruleId": ""
             }
         ],
         [
@@ -4363,7 +4620,8 @@
                 "value": null,
                 "on": false,
                 "off": true,
-                "source": "prerequisite"
+                "source": "prerequisite",
+                "ruleId": ""
             }
         ],
         [
@@ -4383,7 +4641,7 @@
                                 "force": "red"
                             },
                             {
-                                "condition": { "country": { "$in": [ "USA", "Mexico" ] } },
+                                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                                 "force": "green"
                             }
                         ]
@@ -4413,7 +4671,8 @@
                 "value": "success",
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -4433,7 +4692,7 @@
                                 "force": "red"
                             },
                             {
-                                "condition": { "country": { "$in": [ "USA", "Mexico" ] } },
+                                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                                 "force": "green"
                             }
                         ]
@@ -4481,7 +4740,8 @@
                 "value": "success",
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -4510,7 +4770,7 @@
                                 "force": "red"
                             },
                             {
-                                "condition": { "country": { "$in": [ "USA", "Mexico" ] } },
+                                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                                 "force": "green"
                             }
                         ]
@@ -4549,7 +4809,8 @@
                 "value": "success",
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -4566,12 +4827,12 @@
                         "rules": [
                             {
                                 "key": "experiment",
-                                "variations": [ 0, 1 ],
+                                "variations": [0, 1],
                                 "hashAttribute": "id",
                                 "hashVersion": 2,
                                 "ranges": [
-                                    [ 0, 0.5 ],
-                                    [ 0.5, 1.0 ]
+                                    [0, 0.5],
+                                    [0.5, 1.0]
                                 ]
                             }
                         ]
@@ -4601,7 +4862,61 @@
                 "value": "success",
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
+            }
+        ],
+        [
+            "Prerequisite experiment flag in target bucket, evaluate skip dependent flag if not bucketed",
+            {
+                "attributes": {
+                    "id": "1234",
+                    "memberType": "basic",
+                    "country": "USA"
+                },
+                "features": {
+                    "parentExperimentFlag": {
+                        "defaultValue": 0,
+                        "rules": [
+                            {
+                                "key": "experiment",
+                                "variations": [0, 1],
+                                "hashAttribute": "id",
+                                "hashVersion": 2,
+                                "ranges": [
+                                    [0, 0.5],
+                                    [0.5, 1.0]
+                                ]
+                            }
+                        ]
+                    },
+                    "childFlag": {
+                        "defaultValue": "default",
+                        "rules": [
+                            {
+                                "parentConditions": [
+                                    {
+                                        "id": "parentExperimentFlag",
+                                        "condition": { "value": 0 },
+                                        "gate": true
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": { "memberType": "basic" },
+                                "force": "success"
+                            }
+                        ]
+                    }
+                }
+            },
+            "childFlag",
+            {
+                "value": null,
+                "on": false,
+                "off": true,
+                "source": "prerequisite",
+                "ruleId": ""
             }
         ],
         [
@@ -4646,7 +4961,73 @@
                 "value": null,
                 "on": false,
                 "off": true,
-                "source": "cyclicPrerequisite"
+                "source": "cyclicPrerequisite",
+                "ruleId": ""
+            }
+        ],
+        [
+            "Multiple references to same prerequisite, do not break",
+            {
+                "attributes": {
+                    "id": "123",
+                    "browser": "edge"
+                },
+                "features": {
+                    "childFlag": {
+                        "defaultValue": true,
+                        "rules": [
+                            {
+                                "parentConditions": [
+                                    {
+                                        "id": "parentFlag",
+                                        "condition": { "value": { "$ne": false } },
+                                        "gate": true
+                                    },
+                                    {
+                                        "id": "parentFlag",
+                                        "condition": { "value": true },
+                                        "gate": true
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": {
+                                    "browser": "safari"
+                                },
+                                "parentConditions": [
+                                    {
+                                        "id": "parentFlag",
+                                        "condition": { "value": true }
+                                    }
+                                ],
+                                "force": "C"
+                            },
+                            {
+                                "condition": {
+                                    "browser": { "$ne": "safari" }
+                                },
+                                "parentConditions": [
+                                    {
+                                        "id": "parentFlag",
+                                        "condition": { "value": true }
+                                    }
+                                ],
+                                "force": "T"
+                            }
+                        ]
+                    },
+                    "parentFlag": {
+                        "defaultValue": true
+                    }
+                }
+            },
+            "childFlag",
+            {
+                "value": "T",
+                "on": true,
+                "off": false,
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -4667,7 +5048,7 @@
                     }
                 },
                 "savedGroups": {
-                    "group_id": [ 123, 456 ]
+                    "group_id": [123, 456]
                 }
             },
             "inGroup_force_rule",
@@ -4675,7 +5056,8 @@
                 "value": true,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -4692,17 +5074,17 @@
                                 "key": "experiment",
                                 "condition": { "id": { "$inGroup": "group_id" } },
                                 "hashVersion": 2,
-                                "variations": [ 1, 2 ],
+                                "variations": [1, 2],
                                 "ranges": [
-                                    [ 0, 0.5 ],
-                                    [ 0.5, 1.0 ]
+                                    [0, 0.5],
+                                    [0.5, 1.0]
                                 ]
                             }
                         ]
                     }
                 },
                 "savedGroups": {
-                    "group_id": [ 123, 456 ]
+                    "group_id": [123, 456]
                 }
             },
             "inGroup_experiment_rule",
@@ -4714,10 +5096,10 @@
                 "experiment": {
                     "hashVersion": 2,
                     "condition": { "id": { "$inGroup": "group_id" } },
-                    "variations": [ 1, 2 ],
+                    "variations": [1, 2],
                     "ranges": [
-                        [ 0, 0.5 ],
-                        [ 0.5, 1.0 ]
+                        [0, 0.5],
+                        [0.5, 1.0]
                     ],
                     "key": "experiment"
                 },
@@ -4732,7 +5114,8 @@
                     "variationId": 0,
                     "bucket": 0.1736,
                     "stickyBucketUsed": false
-                }
+                },
+                "ruleId": ""
             }
         ]
     ],
@@ -4740,10 +5123,7 @@
         [
             "default weights - 1",
             { "attributes": { "id": "1" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ]
-            },
+            { "key": "my-test", "variations": [0, 1] },
             1,
             true,
             true
@@ -4751,10 +5131,7 @@
         [
             "default weights - 2",
             { "attributes": { "id": "2" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ]
-            },
+            { "key": "my-test", "variations": [0, 1] },
             0,
             true,
             true
@@ -4762,10 +5139,7 @@
         [
             "default weights - 3",
             { "attributes": { "id": "3" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ]
-            },
+            { "key": "my-test", "variations": [0, 1] },
             0,
             true,
             true
@@ -4773,10 +5147,7 @@
         [
             "default weights - 4",
             { "attributes": { "id": "4" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ]
-            },
+            { "key": "my-test", "variations": [0, 1] },
             1,
             true,
             true
@@ -4784,10 +5155,7 @@
         [
             "default weights - 5",
             { "attributes": { "id": "5" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ]
-            },
+            { "key": "my-test", "variations": [0, 1] },
             1,
             true,
             true
@@ -4795,10 +5163,7 @@
         [
             "default weights - 6",
             { "attributes": { "id": "6" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ]
-            },
+            { "key": "my-test", "variations": [0, 1] },
             1,
             true,
             true
@@ -4806,10 +5171,7 @@
         [
             "default weights - 7",
             { "attributes": { "id": "7" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ]
-            },
+            { "key": "my-test", "variations": [0, 1] },
             0,
             true,
             true
@@ -4817,10 +5179,7 @@
         [
             "default weights - 8",
             { "attributes": { "id": "8" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ]
-            },
+            { "key": "my-test", "variations": [0, 1] },
             1,
             true,
             true
@@ -4828,10 +5187,7 @@
         [
             "default weights - 9",
             { "attributes": { "id": "9" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ]
-            },
+            { "key": "my-test", "variations": [0, 1] },
             0,
             true,
             true
@@ -4839,11 +5195,7 @@
         [
             "uneven weights - 1",
             { "attributes": { "id": "1" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
-            },
+            { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
             1,
             true,
             true
@@ -4851,11 +5203,7 @@
         [
             "uneven weights - 2",
             { "attributes": { "id": "2" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
-            },
+            { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
             1,
             true,
             true
@@ -4863,11 +5211,7 @@
         [
             "uneven weights - 3",
             { "attributes": { "id": "3" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
-            },
+            { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
             0,
             true,
             true
@@ -4875,11 +5219,7 @@
         [
             "uneven weights - 4",
             { "attributes": { "id": "4" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
-            },
+            { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
             1,
             true,
             true
@@ -4887,11 +5227,7 @@
         [
             "uneven weights - 5",
             { "attributes": { "id": "5" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
-            },
+            { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
             1,
             true,
             true
@@ -4899,11 +5235,7 @@
         [
             "uneven weights - 6",
             { "attributes": { "id": "6" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
-            },
+            { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
             1,
             true,
             true
@@ -4911,11 +5243,7 @@
         [
             "uneven weights - 7",
             { "attributes": { "id": "7" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
-            },
+            { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
             0,
             true,
             true
@@ -4923,11 +5251,7 @@
         [
             "uneven weights - 8",
             { "attributes": { "id": "8" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
-            },
+            { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
             1,
             true,
             true
@@ -4935,11 +5259,7 @@
         [
             "uneven weights - 9",
             { "attributes": { "id": "9" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
-            },
+            { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
             1,
             true,
             true
@@ -4947,11 +5267,7 @@
         [
             "coverage - 1",
             { "attributes": { "id": "1" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "coverage": 0.4
-            },
+            { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
             0,
             false,
             false
@@ -4959,11 +5275,7 @@
         [
             "coverage - 2",
             { "attributes": { "id": "2" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "coverage": 0.4
-            },
+            { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
             0,
             true,
             true
@@ -4971,11 +5283,7 @@
         [
             "coverage - 3",
             { "attributes": { "id": "3" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "coverage": 0.4
-            },
+            { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
             0,
             true,
             true
@@ -4983,11 +5291,7 @@
         [
             "coverage - 4",
             { "attributes": { "id": "4" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "coverage": 0.4
-            },
+            { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
             0,
             false,
             false
@@ -4995,11 +5299,7 @@
         [
             "coverage - 5",
             { "attributes": { "id": "5" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "coverage": 0.4
-            },
+            { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
             1,
             true,
             true
@@ -5007,11 +5307,7 @@
         [
             "coverage - 6",
             { "attributes": { "id": "6" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "coverage": 0.4
-            },
+            { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
             0,
             false,
             false
@@ -5019,11 +5315,7 @@
         [
             "coverage - 7",
             { "attributes": { "id": "7" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "coverage": 0.4
-            },
+            { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
             0,
             true,
             true
@@ -5031,11 +5323,7 @@
         [
             "coverage - 8",
             { "attributes": { "id": "8" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "coverage": 0.4
-            },
+            { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
             1,
             true,
             true
@@ -5043,11 +5331,7 @@
         [
             "coverage - 9",
             { "attributes": { "id": "9" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "coverage": 0.4
-            },
+            { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
             0,
             false,
             false
@@ -5055,10 +5339,7 @@
         [
             "three way test - 1",
             { "attributes": { "id": "1" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1, 2 ]
-            },
+            { "key": "my-test", "variations": [0, 1, 2] },
             2,
             true,
             true
@@ -5066,10 +5347,7 @@
         [
             "three way test - 2",
             { "attributes": { "id": "2" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1, 2 ]
-            },
+            { "key": "my-test", "variations": [0, 1, 2] },
             0,
             true,
             true
@@ -5077,10 +5355,7 @@
         [
             "three way test - 3",
             { "attributes": { "id": "3" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1, 2 ]
-            },
+            { "key": "my-test", "variations": [0, 1, 2] },
             0,
             true,
             true
@@ -5088,10 +5363,7 @@
         [
             "three way test - 4",
             { "attributes": { "id": "4" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1, 2 ]
-            },
+            { "key": "my-test", "variations": [0, 1, 2] },
             2,
             true,
             true
@@ -5099,10 +5371,7 @@
         [
             "three way test - 5",
             { "attributes": { "id": "5" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1, 2 ]
-            },
+            { "key": "my-test", "variations": [0, 1, 2] },
             1,
             true,
             true
@@ -5110,10 +5379,7 @@
         [
             "three way test - 6",
             { "attributes": { "id": "6" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1, 2 ]
-            },
+            { "key": "my-test", "variations": [0, 1, 2] },
             2,
             true,
             true
@@ -5121,10 +5387,7 @@
         [
             "three way test - 7",
             { "attributes": { "id": "7" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1, 2 ]
-            },
+            { "key": "my-test", "variations": [0, 1, 2] },
             0,
             true,
             true
@@ -5132,10 +5395,7 @@
         [
             "three way test - 8",
             { "attributes": { "id": "8" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1, 2 ]
-            },
+            { "key": "my-test", "variations": [0, 1, 2] },
             1,
             true,
             true
@@ -5143,10 +5403,7 @@
         [
             "three way test - 9",
             { "attributes": { "id": "9" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1, 2 ]
-            },
+            { "key": "my-test", "variations": [0, 1, 2] },
             0,
             true,
             true
@@ -5154,10 +5411,7 @@
         [
             "test name - my-test",
             { "attributes": { "id": "1" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ]
-            },
+            { "key": "my-test", "variations": [0, 1] },
             1,
             true,
             true
@@ -5165,10 +5419,7 @@
         [
             "test name - my-test-3",
             { "attributes": { "id": "1" } },
-            {
-                "key": "my-test-3",
-                "variations": [ 0, 1 ]
-            },
+            { "key": "my-test-3", "variations": [0, 1] },
             0,
             true,
             true
@@ -5176,10 +5427,7 @@
         [
             "empty id",
             { "attributes": { "id": "" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ]
-            },
+            { "key": "my-test", "variations": [0, 1] },
             0,
             false,
             false
@@ -5187,10 +5435,7 @@
         [
             "null id",
             { "attributes": { "id": null } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ]
-            },
+            { "key": "my-test", "variations": [0, 1] },
             0,
             false,
             false
@@ -5198,10 +5443,7 @@
         [
             "missing id",
             { "attributes": {} },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ]
-            },
+            { "key": "my-test", "variations": [0, 1] },
             0,
             false,
             false
@@ -5209,10 +5451,7 @@
         [
             "missing attributes",
             {},
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ]
-            },
+            { "key": "my-test", "variations": [0, 1] },
             0,
             false,
             false
@@ -5220,10 +5459,7 @@
         [
             "single variation",
             { "attributes": { "id": "1" } },
-            {
-                "key": "my-test",
-                "variations": [ 0 ]
-            },
+            { "key": "my-test", "variations": [0] },
             0,
             false,
             false
@@ -5231,11 +5467,7 @@
         [
             "negative forced variation",
             { "attributes": { "id": "1" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "force": -8
-            },
+            { "key": "my-test", "variations": [0, 1], "force": -8 },
             0,
             false,
             false
@@ -5243,11 +5475,7 @@
         [
             "high forced variation",
             { "attributes": { "id": "1" } },
-            {
-                "key": "my-test",
-                "variations": [ 0, 1 ],
-                "force": 25
-            },
+            { "key": "my-test", "variations": [0, 1], "force": 25 },
             0,
             false,
             false
@@ -5262,7 +5490,7 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [0, 1],
                 "condition": {
                     "browser": "firefox"
                 }
@@ -5281,7 +5509,7 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [0, 1],
                 "condition": {
                     "browser": "firefox"
                 }
@@ -5300,7 +5528,7 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [0, 1],
                 "hashAttribute": "companyId"
             },
             1,
@@ -5317,7 +5545,7 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [0, 1]
             },
             0,
             false,
@@ -5333,7 +5561,7 @@
             },
             {
                 "key": "forced-test-qs",
-                "variations": [ 0, 1 ]
+                "variations": [0, 1]
             },
             1,
             true,
@@ -5349,7 +5577,7 @@
             {
                 "key": "my-test",
                 "active": true,
-                "variations": [ 0, 1 ]
+                "variations": [0, 1]
             },
             1,
             true,
@@ -5365,7 +5593,7 @@
             {
                 "key": "my-test",
                 "active": false,
-                "variations": [ 0, 1 ]
+                "variations": [0, 1]
             },
             0,
             false,
@@ -5382,7 +5610,7 @@
             {
                 "key": "my-test",
                 "active": false,
-                "variations": [ 0, 1 ]
+                "variations": [0, 1]
             },
             1,
             true,
@@ -5399,7 +5627,7 @@
                 "key": "my-test",
                 "force": 1,
                 "coverage": 0.01,
-                "variations": [ 0, 1 ]
+                "variations": [0, 1]
             },
             0,
             false,
@@ -5440,7 +5668,7 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [0, 1]
             },
             0,
             true,
@@ -5454,7 +5682,7 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [0, 1]
             },
             0,
             false,
@@ -5469,7 +5697,7 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [0, 1]
             },
             1,
             true,
@@ -5483,7 +5711,7 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [0, 1],
                 "force": 1
             },
             1,
@@ -5499,8 +5727,8 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
-                "namespace": [ "namespace", 0.1, 1 ]
+                "variations": [0, 1],
+                "namespace": ["namespace", 0.1, 1]
             },
             1,
             true,
@@ -5515,8 +5743,8 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
-                "namespace": [ "namespace", 0, 0.1 ]
+                "variations": [0, 1],
+                "namespace": ["namespace", 0, 0.1]
             },
             0,
             false,
@@ -5531,7 +5759,7 @@
             },
             {
                 "key": "no-coverage",
-                "variations": [ 0, 1 ],
+                "variations": [0, 1],
                 "coverage": 0
             },
             0,
@@ -5548,19 +5776,19 @@
             },
             {
                 "key": "filtered",
-                "variations": [ 0, 1 ],
+                "variations": [0, 1],
                 "filters": [
                     {
                         "seed": "seed",
                         "ranges": [
-                            [ 0, 0.1 ],
-                            [ 0.2, 0.4 ]
+                            [0, 0.1],
+                            [0.2, 0.4]
                         ]
                     },
                     {
                         "seed": "seed",
                         "attribute": "anonId",
-                        "ranges": [ [ 0.8, 1.0 ] ]
+                        "ranges": [[0.8, 1.0]]
                     }
                 ]
             },
@@ -5578,19 +5806,19 @@
             },
             {
                 "key": "filtered",
-                "variations": [ 0, 1 ],
+                "variations": [0, 1],
                 "filters": [
                     {
                         "seed": "seed",
                         "ranges": [
-                            [ 0, 0.1 ],
-                            [ 0.2, 0.4 ]
+                            [0, 0.1],
+                            [0.2, 0.4]
                         ]
                     },
                     {
                         "seed": "seed",
                         "attribute": "anonId",
-                        "ranges": [ [ 0.6, 0.8 ] ]
+                        "ranges": [[0.6, 0.8]]
                     }
                 ]
             },
@@ -5607,17 +5835,17 @@
             },
             {
                 "key": "filtered",
-                "variations": [ 0, 1 ],
+                "variations": [0, 1],
                 "filters": [
                     {
                         "seed": "seed",
                         "ranges": [
-                            [ 0, 0.1 ],
-                            [ 0.2, 0.4 ]
+                            [0, 0.1],
+                            [0.2, 0.4]
                         ]
                     }
                 ],
-                "namespace": [ "test", 0, 0.001 ]
+                "namespace": ["test", 0, 0.001]
             },
             1,
             true,
@@ -5632,13 +5860,13 @@
             },
             {
                 "key": "ranges",
-                "variations": [ 0, 1 ],
+                "variations": [0, 1],
                 "ranges": [
-                    [ 0.99, 1.0 ],
-                    [ 0.0, 0.99 ]
+                    [0.99, 1.0],
+                    [0.0, 0.99]
                 ],
                 "coverage": 0.01,
-                "weights": [ 0.99, 0.01 ]
+                "weights": [0.99, 0.01]
             },
             1,
             true,
@@ -5653,10 +5881,10 @@
             },
             {
                 "key": "configs",
-                "variations": [ 0, 1 ],
+                "variations": [0, 1],
                 "ranges": [
-                    [ 0, 0.1 ],
-                    [ 0.9, 1.0 ]
+                    [0, 0.1],
+                    [0.9, 1.0]
                 ]
             },
             0,
@@ -5674,10 +5902,10 @@
                 "key": "key",
                 "seed": "foo",
                 "hashVersion": 2,
-                "variations": [ 0, 1 ],
+                "variations": [0, 1],
                 "ranges": [
-                    [ 0, 0.5 ],
-                    [ 0.5, 1.0 ]
+                    [0, 0.5],
+                    [0.5, 1.0]
                 ]
             },
             1,
@@ -5695,7 +5923,7 @@
                 "key": "key",
                 "seed": "foo",
                 "hashVersion": 2,
-                "variations": [ 0, 1 ]
+                "variations": [0, 1]
             },
             1,
             true,
@@ -5712,8 +5940,8 @@
                 "key": "key",
                 "seed": "foo",
                 "hashVersion": 2,
-                "variations": [ 0, 1 ],
-                "weights": [ 0.5, 0.5 ],
+                "variations": [0, 1],
+                "weights": [0.5, 0.5],
                 "coverage": 0.99
             },
             1,
@@ -5732,7 +5960,7 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [0, 1],
                 "parentConditions": [
                     {
                         "id": "parentFlag",
@@ -5758,7 +5986,7 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [0, 1],
                 "parentConditions": [
                     {
                         "id": "parentFlag",
@@ -5776,14 +6004,14 @@
             "SavedGroups correctly pulled from context for experiment",
             {
                 "attributes": { "id": "4" },
-                "savedGroups": { "group_id": [ "4", "5", "6" ] }
+                "savedGroups": { "group_id": ["4", "5", "6"] }
             },
             {
                 "key": "group-filtered-test",
                 "condition": {
                     "id": { "$inGroup": "group_id" }
                 },
-                "variations": [ 0, 1, 2 ]
+                "variations": [0, 1, 2]
             },
             0,
             true,
@@ -5795,8 +6023,8 @@
             "even range, 0.2",
             0.2,
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [0, 0.5],
+                [0.5, 1]
             ],
             0
         ],
@@ -5804,8 +6032,8 @@
             "even range, 0.4",
             0.4,
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [0, 0.5],
+                [0.5, 1]
             ],
             0
         ],
@@ -5813,8 +6041,8 @@
             "even range, 0.6",
             0.6,
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [0, 0.5],
+                [0.5, 1]
             ],
             1
         ],
@@ -5822,8 +6050,8 @@
             "even range, 0.8",
             0.8,
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [0, 0.5],
+                [0.5, 1]
             ],
             1
         ],
@@ -5831,8 +6059,8 @@
             "even range, 0",
             0,
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [0, 0.5],
+                [0.5, 1]
             ],
             0
         ],
@@ -5840,8 +6068,8 @@
             "even range, 0.5",
             0.5,
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [0, 0.5],
+                [0.5, 1]
             ],
             1
         ],
@@ -5849,8 +6077,8 @@
             "reduced range, 0.2",
             0.2,
             [
-                [ 0, 0.25 ],
-                [ 0.5, 0.75 ]
+                [0, 0.25],
+                [0.5, 0.75]
             ],
             0
         ],
@@ -5858,8 +6086,8 @@
             "reduced range, 0.4",
             0.4,
             [
-                [ 0, 0.25 ],
-                [ 0.5, 0.75 ]
+                [0, 0.25],
+                [0.5, 0.75]
             ],
             -1
         ],
@@ -5867,8 +6095,8 @@
             "reduced range, 0.6",
             0.6,
             [
-                [ 0, 0.25 ],
-                [ 0.5, 0.75 ]
+                [0, 0.25],
+                [0.5, 0.75]
             ],
             1
         ],
@@ -5876,8 +6104,8 @@
             "reduced range, 0.8",
             0.8,
             [
-                [ 0, 0.25 ],
-                [ 0.5, 0.75 ]
+                [0, 0.25],
+                [0.5, 0.75]
             ],
             -1
         ],
@@ -5885,8 +6113,8 @@
             "reduced range, 0.25",
             0.25,
             [
-                [ 0, 0.25 ],
-                [ 0.5, 0.75 ]
+                [0, 0.25],
+                [0.5, 0.75]
             ],
             -1
         ],
@@ -5894,8 +6122,8 @@
             "reduced range, 0.5",
             0.5,
             [
-                [ 0, 0.25 ],
-                [ 0.5, 0.75 ]
+                [0, 0.25],
+                [0.5, 0.75]
             ],
             1
         ],
@@ -5903,17 +6131,17 @@
             "zero range",
             0.5,
             [
-                [ 0, 0.5 ],
-                [ 0.5, 0.5 ],
-                [ 0.5, 1 ]
+                [0, 0.5],
+                [0.5, 0.5],
+                [0.5, 1]
             ],
             2
         ]
     ],
     "getQueryStringOverride": [
-        [ "empty url", "my-test", "", 2, null ],
-        [ "no query string", "my-test", "http://example.com", 2, null ],
-        [ "empty query string", "my-test", "http://example.com?", 2, null ],
+        ["empty url", "my-test", "", 2, null],
+        ["no query string", "my-test", "http://example.com", 2, null],
+        ["empty query string", "my-test", "http://example.com?", 2, null],
         [
             "no query string match",
             "my-test",
@@ -5921,14 +6149,14 @@
             2,
             null
         ],
-        [ "invalid query string", "my-test", "http://example.com??&&&?#", 2, null ],
-        [ "simple match 0", "my-test", "http://example.com?my-test=0", 2, 0 ],
-        [ "simple match 1", "my-test", "http://example.com?my-test=1", 2, 1 ],
-        [ "negative variation", "my-test", "http://example.com?my-test=-1", 2, null ],
-        [ "float", "my-test", "http://example.com?my-test=2.054", 2, null ],
-        [ "string", "my-test", "http://example.com?my-test=foo", 2, null ],
-        [ "variation too high", "my-test", "http://example.com?my-test=5", 2, null ],
-        [ "high numVariations", "my-test", "http://example.com?my-test=5", 6, 5 ],
+        ["invalid query string", "my-test", "http://example.com??&&&?#", 2, null],
+        ["simple match 0", "my-test", "http://example.com?my-test=0", 2, 0],
+        ["simple match 1", "my-test", "http://example.com?my-test=1", 2, 1],
+        ["negative variation", "my-test", "http://example.com?my-test=-1", 2, null],
+        ["float", "my-test", "http://example.com?my-test=2.054", 2, null],
+        ["string", "my-test", "http://example.com?my-test=foo", 2, null],
+        ["variation too high", "my-test", "http://example.com?my-test=5", 2, null],
+        ["high numVariations", "my-test", "http://example.com?my-test=5", 6, 5],
         [
             "equal to numVariations",
             "my-test",
@@ -5950,131 +6178,33 @@
             2,
             1
         ],
-        [ "anchor", "my-test", "http://example.com?my-test=1#foo", 2, 1 ]
+        ["anchor", "my-test", "http://example.com?my-test=1#foo", 2, 1]
     ],
     "inNamespace": [
-        [
-            "user 1, namespace1, 1",
-            "1",
-            [ "namespace1", 0, 0.4 ],
-            false
-        ],
-        [
-            "user 1, namespace1, 2",
-            "1",
-            [ "namespace1", 0.4, 1 ],
-            true
-        ],
-        [
-            "user 1, namespace2, 1",
-            "1",
-            [ "namespace2", 0, 0.4 ],
-            false
-        ],
-        [
-            "user 1, namespace2, 2",
-            "1",
-            [ "namespace2", 0.4, 1 ],
-            true
-        ],
-        [
-            "user 2, namespace1, 1",
-            "2",
-            [ "namespace1", 0, 0.4 ],
-            false
-        ],
-        [
-            "user 2, namespace1, 2",
-            "2",
-            [ "namespace1", 0.4, 1 ],
-            true
-        ],
-        [
-            "user 2, namespace2, 1",
-            "2",
-            [ "namespace2", 0, 0.4 ],
-            false
-        ],
-        [
-            "user 2, namespace2, 2",
-            "2",
-            [ "namespace2", 0.4, 1 ],
-            true
-        ],
-        [
-            "user 3, namespace1, 1",
-            "3",
-            [ "namespace1", 0, 0.4 ],
-            false
-        ],
-        [
-            "user 3, namespace1, 2",
-            "3",
-            [ "namespace1", 0.4, 1 ],
-            true
-        ],
-        [
-            "user 3, namespace2, 1",
-            "3",
-            [ "namespace2", 0, 0.4 ],
-            true
-        ],
-        [
-            "user 3, namespace2, 2",
-            "3",
-            [ "namespace2", 0.4, 1 ],
-            false
-        ],
-        [
-            "user 4, namespace1, 1",
-            "4",
-            [ "namespace1", 0, 0.4 ],
-            false
-        ],
-        [
-            "user 4, namespace1, 2",
-            "4",
-            [ "namespace1", 0.4, 1 ],
-            true
-        ],
-        [
-            "user 4, namespace2, 1",
-            "4",
-            [ "namespace2", 0, 0.4 ],
-            true
-        ],
-        [
-            "user 4, namespace2, 2",
-            "4",
-            [ "namespace2", 0.4, 1 ],
-            false
-        ]
+        ["user 1, namespace1, 1", "1", ["namespace1", 0, 0.4], false],
+        ["user 1, namespace1, 2", "1", ["namespace1", 0.4, 1], true],
+        ["user 1, namespace2, 1", "1", ["namespace2", 0, 0.4], false],
+        ["user 1, namespace2, 2", "1", ["namespace2", 0.4, 1], true],
+        ["user 2, namespace1, 1", "2", ["namespace1", 0, 0.4], false],
+        ["user 2, namespace1, 2", "2", ["namespace1", 0.4, 1], true],
+        ["user 2, namespace2, 1", "2", ["namespace2", 0, 0.4], false],
+        ["user 2, namespace2, 2", "2", ["namespace2", 0.4, 1], true],
+        ["user 3, namespace1, 1", "3", ["namespace1", 0, 0.4], false],
+        ["user 3, namespace1, 2", "3", ["namespace1", 0.4, 1], true],
+        ["user 3, namespace2, 1", "3", ["namespace2", 0, 0.4], true],
+        ["user 3, namespace2, 2", "3", ["namespace2", 0.4, 1], false],
+        ["user 4, namespace1, 1", "4", ["namespace1", 0, 0.4], false],
+        ["user 4, namespace1, 2", "4", ["namespace1", 0.4, 1], true],
+        ["user 4, namespace2, 1", "4", ["namespace2", 0, 0.4], true],
+        ["user 4, namespace2, 2", "4", ["namespace2", 0.4, 1], false]
     ],
     "getEqualWeights": [
-        [
-            -1,
-            []
-        ],
-        [
-            0,
-            []
-        ],
-        [
-            1,
-            [ 1 ]
-        ],
-        [
-            2,
-            [ 0.5, 0.5 ]
-        ],
-        [
-            3,
-            [ 0.33333333, 0.33333333, 0.33333333 ]
-        ],
-        [
-            4,
-            [ 0.25, 0.25, 0.25, 0.25 ]
-        ]
+        [-1, []],
+        [0, []],
+        [1, [1]],
+        [2, [0.5, 0.5]],
+        [3, [0.33333333, 0.33333333, 0.33333333]],
+        [4, [0.25, 0.25, 0.25, 0.25]]
     ],
     "decrypt": [
         [
@@ -6148,7 +6278,7 @@
                         "defaultValue": 0,
                         "rules": [
                             {
-                                "variations": [ 0, 1, 2, 3 ],
+                                "variations": [0, 1, 2, 3],
                                 "hashAttribute": "id",
                                 "fallbackAttribute": "anonymousId"
                             }
@@ -6199,14 +6329,10 @@
                                 "hashVersion": 2,
                                 "bucketVersion": 0,
                                 "condition": { "country": "USA" },
-                                "variations": [ "control", "red", "blue" ],
-                                "meta": [
-                                    { "key": "0" },
-                                    { "key": "1" },
-                                    { "key": "2" }
-                                ],
+                                "variations": ["control", "red", "blue"],
+                                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                                 "coverage": 1,
-                                "weights": [ 0.3334, 0.3333, 0.3333 ],
+                                "weights": [0.3334, 0.3333, 0.3333],
                                 "phase": "0"
                             }
                         ]
@@ -6257,14 +6383,10 @@
                                 "hashVersion": 2,
                                 "bucketVersion": 0,
                                 "condition": { "country": "USA" },
-                                "variations": [ "control", "red", "blue" ],
-                                "meta": [
-                                    { "key": "0" },
-                                    { "key": "1" },
-                                    { "key": "2" }
-                                ],
+                                "variations": ["control", "red", "blue"],
+                                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                                 "coverage": 1,
-                                "weights": [ 0.3334, 0.3333, 0.3333 ],
+                                "weights": [0.3334, 0.3333, 0.3333],
                                 "phase": "0"
                             }
                         ]
@@ -6322,14 +6444,10 @@
                                 "hashVersion": 2,
                                 "bucketVersion": 0,
                                 "condition": { "country": "USA" },
-                                "variations": [ "control", "red", "blue" ],
-                                "meta": [
-                                    { "key": "0" },
-                                    { "key": "1" },
-                                    { "key": "2" }
-                                ],
+                                "variations": ["control", "red", "blue"],
+                                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                                 "coverage": 1,
-                                "weights": [ 0.3334, 0.3333, 0.3333 ],
+                                "weights": [0.3334, 0.3333, 0.3333],
                                 "phase": "0"
                             }
                         ]
@@ -6387,14 +6505,10 @@
                                 "hashVersion": 2,
                                 "bucketVersion": 0,
                                 "condition": { "country": "USA" },
-                                "variations": [ "control", "red", "blue" ],
-                                "meta": [
-                                    { "key": "0" },
-                                    { "key": "1" },
-                                    { "key": "2" }
-                                ],
+                                "variations": ["control", "red", "blue"],
+                                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                                 "coverage": 1,
-                                "weights": [ 0.3334, 0.3333, 0.3333 ],
+                                "weights": [0.3334, 0.3333, 0.3333],
                                 "phase": "0"
                             }
                         ]
@@ -6457,14 +6571,10 @@
                                 "hashVersion": 2,
                                 "bucketVersion": 0,
                                 "condition": { "country": "USA" },
-                                "variations": [ "control", "red", "blue" ],
-                                "meta": [
-                                    { "key": "0" },
-                                    { "key": "1" },
-                                    { "key": "2" }
-                                ],
+                                "variations": ["control", "red", "blue"],
+                                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                                 "coverage": 1,
-                                "weights": [ 0.3334, 0.3333, 0.3333 ],
+                                "weights": [0.3334, 0.3333, 0.3333],
                                 "phase": "0"
                             }
                         ]
@@ -6533,14 +6643,10 @@
                                 "hashVersion": 2,
                                 "bucketVersion": 3,
                                 "condition": { "country": "USA" },
-                                "variations": [ "control", "red", "blue" ],
-                                "meta": [
-                                    { "key": "0" },
-                                    { "key": "1" },
-                                    { "key": "2" }
-                                ],
+                                "variations": ["control", "red", "blue"],
+                                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                                 "coverage": 1,
-                                "weights": [ 0.3334, 0.3333, 0.3333 ],
+                                "weights": [0.3334, 0.3333, 0.3333],
                                 "phase": "0"
                             }
                         ]
@@ -6599,14 +6705,10 @@
                                 "bucketVersion": 3,
                                 "minBucketVersion": 3,
                                 "condition": { "country": "USA" },
-                                "variations": [ "control", "red", "blue" ],
-                                "meta": [
-                                    { "key": "0" },
-                                    { "key": "1" },
-                                    { "key": "2" }
-                                ],
+                                "variations": ["control", "red", "blue"],
+                                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                                 "coverage": 1,
-                                "weights": [ 0.3334, 0.3333, 0.3333 ],
+                                "weights": [0.3334, 0.3333, 0.3333],
                                 "phase": "0"
                             }
                         ]
@@ -6633,6 +6735,249 @@
             }
         ],
         [
+            "uses a sticky bucket when sticky bucket version == experiment.minBucketVersion === experiment.bucketVersion",
+            {
+                "attributes": {
+                    "deviceId": "d123",
+                    "anonymousId": "ses123",
+                    "foo": "bar",
+                    "country": "USA"
+                },
+                "features": {
+                    "exp1": {
+                        "defaultValue": "control",
+                        "rules": [
+                            {
+                                "key": "feature-exp",
+                                "seed": "feature-exp",
+                                "hashAttribute": "id",
+                                "fallbackAttribute": "deviceId",
+                                "hashVersion": 2,
+                                "bucketVersion": 3,
+                                "minBucketVersion": 3,
+                                "condition": { "country": "USA" },
+                                "variations": ["control", "red", "blue"],
+                                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                                "coverage": 1,
+                                "weights": [0.3334, 0.3333, 0.3333],
+                                "phase": "0"
+                            }
+                        ]
+                    }
+                }
+            },
+            [
+                {
+                    "attributeName": "deviceId",
+                    "attributeValue": "d123",
+                    "assignments": {
+                        "feature-exp__3": "2"
+                    }
+                }
+            ],
+            "exp1",
+            {
+                "bucket": 0.6468,
+                "featureId": "exp1",
+                "hashAttribute": "deviceId",
+                "hashUsed": true,
+                "hashValue": "d123",
+                "inExperiment": true,
+                "key": "2",
+                "stickyBucketUsed": true,
+                "value": "blue",
+                "variationId": 2
+            },
+            {
+                "deviceId||d123": {
+                    "assignments": { "feature-exp__3": "2" },
+                    "attributeName": "deviceId",
+                    "attributeValue": "d123"
+                }
+            }
+        ],
+        [
+            "skips assignment when sticky bucket version < experiment.minBucketVersion",
+            {
+                "attributes": {
+                    "deviceId": "d123",
+                    "anonymousId": "ses123",
+                    "foo": "bar",
+                    "country": "USA"
+                },
+                "features": {
+                    "exp1": {
+                        "defaultValue": "control",
+                        "rules": [
+                            {
+                                "key": "feature-exp",
+                                "seed": "feature-exp",
+                                "hashAttribute": "id",
+                                "fallbackAttribute": "deviceId",
+                                "hashVersion": 2,
+                                "bucketVersion": 3,
+                                "minBucketVersion": 3,
+                                "condition": { "country": "USA" },
+                                "variations": ["control", "red", "blue"],
+                                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                                "coverage": 1,
+                                "weights": [0.3334, 0.3333, 0.3333],
+                                "phase": "0"
+                            }
+                        ]
+                    }
+                }
+            },
+            [
+                {
+                    "attributeName": "deviceId",
+                    "attributeValue": "d123",
+                    "assignments": {
+                        "feature-exp__2": "2"
+                    }
+                }
+            ],
+            "exp1",
+            null,
+            {
+                "deviceId||d123": {
+                    "assignments": { "feature-exp__2": "2" },
+                    "attributeName": "deviceId",
+                    "attributeValue": "d123"
+                }
+            }
+        ],
+        [
+            "resets sticky bucketing when bucket version > experiment.bucketVersion (invalid version)",
+            {
+                "attributes": {
+                    "deviceId": "d123",
+                    "anonymousId": "ses123",
+                    "foo": "bar",
+                    "country": "USA"
+                },
+                "features": {
+                    "exp1": {
+                        "defaultValue": "control",
+                        "rules": [
+                            {
+                                "key": "feature-exp",
+                                "seed": "feature-exp",
+                                "hashAttribute": "id",
+                                "fallbackAttribute": "deviceId",
+                                "hashVersion": 2,
+                                "bucketVersion": 3,
+                                "minBucketVersion": 3,
+                                "condition": { "country": "USA" },
+                                "variations": ["control", "red", "blue"],
+                                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                                "coverage": 1,
+                                "weights": [0.3334, 0.3333, 0.3333],
+                                "phase": "0"
+                            }
+                        ]
+                    }
+                }
+            },
+            [
+                {
+                    "attributeName": "deviceId",
+                    "attributeValue": "d123",
+                    "assignments": {
+                        "feature-exp__4": "2"
+                    }
+                }
+            ],
+            "exp1",
+            {
+                "bucket": 0.6468,
+                "featureId": "exp1",
+                "hashAttribute": "deviceId",
+                "hashUsed": true,
+                "hashValue": "d123",
+                "inExperiment": true,
+                "key": "1",
+                "stickyBucketUsed": false,
+                "value": "red",
+                "variationId": 1
+            },
+            {
+                "deviceId||d123": {
+                    "assignments": {
+                        "feature-exp__3": "1",
+                        "feature-exp__4": "2"
+                    },
+                    "attributeName": "deviceId",
+                    "attributeValue": "d123"
+                }
+            }
+        ],
+        [
+            "resets sticky bucketing when bucket version < experiment.bucketVersion (invalid version)",
+            {
+                "attributes": {
+                    "deviceId": "d123",
+                    "anonymousId": "ses123",
+                    "foo": "bar",
+                    "country": "USA"
+                },
+                "features": {
+                    "exp1": {
+                        "defaultValue": "control",
+                        "rules": [
+                            {
+                                "key": "feature-exp",
+                                "seed": "feature-exp",
+                                "hashAttribute": "id",
+                                "fallbackAttribute": "deviceId",
+                                "hashVersion": 2,
+                                "bucketVersion": 4,
+                                "minBucketVersion": 3,
+                                "condition": { "country": "USA" },
+                                "variations": ["control", "red", "blue"],
+                                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                                "coverage": 1,
+                                "weights": [0.3334, 0.3333, 0.3333],
+                                "phase": "0"
+                            }
+                        ]
+                    }
+                }
+            },
+            [
+                {
+                    "attributeName": "deviceId",
+                    "attributeValue": "d123",
+                    "assignments": {
+                        "feature-exp__3": "2"
+                    }
+                }
+            ],
+            "exp1",
+            {
+                "bucket": 0.6468,
+                "featureId": "exp1",
+                "hashAttribute": "deviceId",
+                "hashUsed": true,
+                "hashValue": "d123",
+                "inExperiment": true,
+                "key": "1",
+                "stickyBucketUsed": false,
+                "value": "red",
+                "variationId": 1
+            },
+            {
+                "deviceId||d123": {
+                    "assignments": {
+                        "feature-exp__3": "2",
+                        "feature-exp__4": "1"
+                    },
+                    "attributeName": "deviceId",
+                    "attributeValue": "d123"
+                }
+            }
+        ],
+        [
             "disables sticky bucketing when disabled by experiment",
             {
                 "attributes": {
@@ -6653,14 +6998,10 @@
                                 "bucketVersion": 1,
                                 "disableStickyBucketing": true,
                                 "condition": { "country": "USA" },
-                                "variations": [ "control", "red", "blue" ],
-                                "meta": [
-                                    { "key": "0" },
-                                    { "key": "1" },
-                                    { "key": "2" }
-                                ],
+                                "variations": ["control", "red", "blue"],
+                                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                                 "coverage": 1,
-                                "weights": [ 0.3334, 0.3333, 0.3333 ],
+                                "weights": [0.3334, 0.3333, 0.3333],
                                 "phase": "0"
                             }
                         ]
@@ -6712,7 +7053,7 @@
                                 "pattern": "http://www.example.com/home"
                             }
                         ],
-                        "weights": [ 0.1, 0.9 ],
+                        "weights": [0.1, 0.9],
                         "variations": [
                             {},
                             {
@@ -6745,7 +7086,7 @@
                                 "pattern": "http://www.example.com/home"
                             }
                         ],
-                        "weights": [ 0.1, 0.9 ],
+                        "weights": [0.1, 0.9],
                         "variations": [
                             {},
                             {
@@ -6779,7 +7120,7 @@
                                 "pattern": "http://www.example.com/home"
                             }
                         ],
-                        "weights": [ 0.1, 0.9 ],
+                        "weights": [0.1, 0.9],
                         "variations": [
                             {},
                             {
@@ -6813,7 +7154,7 @@
                                 "pattern": "http://www.example.com/"
                             }
                         ],
-                        "weights": [ 0.1, 0.9 ],
+                        "weights": [0.1, 0.9],
                         "variations": [
                             {},
                             {
@@ -6830,7 +7171,7 @@
                                 "pattern": "http://www.example.com/home"
                             }
                         ],
-                        "weights": [ 0.1, 0.9 ],
+                        "weights": [0.1, 0.9],
                         "variations": [
                             {},
                             {
@@ -6847,7 +7188,7 @@
                                 "pattern": "http://www.example.com/home"
                             }
                         ],
-                        "weights": [ 0.1, 0.9 ],
+                        "weights": [0.1, 0.9],
                         "variations": [
                             {},
                             {

--- a/GrowthBook/Providers/ConditionEvaluationProvider.cs
+++ b/GrowthBook/Providers/ConditionEvaluationProvider.cs
@@ -127,9 +127,15 @@ namespace GrowthBook.Providers
         /// <param name="conditionValue">The condition value to check.</param>
         /// <param name="attributeValue">The attribute value to check.</param>
         /// <returns>True if the condition value matches the attribute value.</returns>
-        private bool EvalConditionValue(JToken conditionValue, JToken attributeValue, JObject savedGroups)
+        private bool EvalConditionValue(JToken conditionValue, JToken attributeValue, JObject savedGroups, Boolean insensitive = false)
         {
             _logger.LogDebug("Evaluating condition value \'{ConditionValue}\'", conditionValue);
+
+            // Simple equality comparison with optional case-insensitivity
+            if (insensitive && conditionValue.Type == JTokenType.String && attributeValue.Type == JTokenType.String)
+            {
+                return conditionValue.ToString().ToLower().Equals(attributeValue.ToString().ToLower());
+            }
 
             if (conditionValue.Type == JTokenType.Object)
             {
@@ -214,15 +220,24 @@ namespace GrowthBook.Providers
 
             if (op == "$regex")
             {
-                try
-                {
-                    return Regex.IsMatch(attributeValue?.ToString(), conditionValue?.ToString());
-                }
-                catch (ArgumentException)
-                {
-                    return false;
-                }
+                return EvalRegex(attributeValue, conditionValue, RegexOptions.None);
             }
+            if (op == "$regexi")
+            {
+                return EvalRegex(attributeValue, conditionValue, RegexOptions.IgnoreCase);
+
+            }
+            if (op == "$notRegex")
+            {
+                return !EvalRegex(attributeValue, conditionValue, RegexOptions.None);
+
+            }
+            if (op == "$notRegexi")
+            {
+                return !EvalRegex(attributeValue, conditionValue, RegexOptions.IgnoreCase);
+
+            }
+
             if (op == "$nregex")
             {
                 try
@@ -242,6 +257,14 @@ namespace GrowthBook.Providers
                 }
                 return IsIn(conditionValue, attributeValue, savedGroups);
             }
+            if (op == "$ini")
+            {
+                if (conditionValue.Type != JTokenType.Array)
+                {
+                    return false;
+                }
+                return IsIn(conditionValue, attributeValue, savedGroups, true);
+            }
             if (op == "$nin")
             {
                 if (conditionValue.Type != JTokenType.Array)
@@ -250,29 +273,22 @@ namespace GrowthBook.Providers
                 }
                 return !IsIn(conditionValue, attributeValue, savedGroups);
             }
-            if (op == "$all")
+            if (op == "$nini")
             {
                 if (conditionValue.Type != JTokenType.Array)
                 {
                     return false;
                 }
-                if (attributeValue?.Type != JTokenType.Array)
-                {
-                    return false;
-                }
+                return !IsIn(conditionValue, attributeValue, savedGroups, true);
+            }
+            if (op == "$all")
+            {
+                return IsInAll(conditionValue, attributeValue, savedGroups,  false);
+            }
 
-                var conditionList = (JArray)conditionValue;
-                var attributeList = (JArray)attributeValue;
-
-                foreach (JToken condition in conditionList)
-                {
-                    if (!attributeList.Any(x => EvalConditionValue(condition, x, savedGroups)))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
+            if (op == "$alli")
+            {
+                return IsInAll(conditionValue, attributeValue, savedGroups,  true);
             }
 
             if (op == "$elemMatch")
@@ -401,8 +417,28 @@ namespace GrowthBook.Providers
             return true;
         }
 
-        private bool IsIn(JToken conditionValue, JToken actualValue, JObject savedGroups)
+        private bool EvalRegex(JToken attributeValue, JToken conditionValue, RegexOptions regexOptions)
         {
+            try
+            {
+                return Regex.IsMatch(
+                    attributeValue?.ToString() ?? string.Empty,
+                    conditionValue?.ToString() ?? string.Empty,
+                    regexOptions);
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+        }
+
+        private bool IsIn(JToken conditionValue, JToken actualValue, JObject savedGroups, Boolean insensitive = false)
+        {
+            JToken СaseFold(JToken value) =>
+                (insensitive && value.Type == JTokenType.String)
+                    ? value.ToString().ToLower()
+                    : value;
+
             if (actualValue?.Type == JTokenType.Array)
             {
                 _logger.LogDebug("Evaluating whether the specified value is in an array");
@@ -410,30 +446,41 @@ namespace GrowthBook.Providers
                 var conditionValues = new HashSet<JToken>(conditionValue);
                 var actualValues = new HashSet<JToken>(actualValue);
 
-                conditionValues.IntersectWith(actualValues);
-
-                return conditionValues.Any();
+                return actualValues.Any(actual =>
+                    conditionValues.Any(conditial =>
+                        JToken.DeepEquals(СaseFold(actual), СaseFold(conditial))));
             }
             else if (conditionValue is JArray array)
             {
-                return array.Any(x => x.Equals(actualValue));
+                return array.Any(x => JToken.DeepEquals(СaseFold(x), СaseFold(actualValue)));
             }
-            else
+
+            return false;
+        }
+
+        private bool IsInAll(JToken conditionValue, JToken attributeValue, JObject savedGroups, Boolean insensitive)
+        {
+            if (conditionValue.Type != JTokenType.Array)
             {
-                _logger.LogDebug("Evaluating whether the specified value is equal to or contained within the actual value");
+                return false;
+            }
+            if (attributeValue?.Type != JTokenType.Array)
+            {
+                return false;
+            }
 
-                if (conditionValue == actualValue)
-                {
-                    return true;
-                }
+            var conditionList = (JArray)conditionValue;
+            var attributeList = (JArray)attributeValue;
 
-                if (conditionValue.IsNullOrWhitespace() || actualValue.IsNullOrWhitespace())
+            foreach (JToken condition in conditionList)
+            {
+                if (!attributeList.Any(x => EvalConditionValue(condition, x, savedGroups, insensitive)))
                 {
                     return false;
                 }
-
-                return conditionValue.ToString().Contains(actualValue.ToString());
             }
+
+            return true;
         }
 
         private static bool CompareVersions(JToken left, JToken right, Func<int, bool> meetsComparison)

--- a/GrowthBook/Providers/ConditionEvaluationProvider.cs
+++ b/GrowthBook/Providers/ConditionEvaluationProvider.cs
@@ -492,9 +492,14 @@ namespace GrowthBook.Providers
         /// <returns>True if the comparison is satisfied, false if attribute is null or comparison fails.</returns>
         private bool EvaluateComparison(JToken attributeValue, JToken conditionValue, Func<int, bool> meetsComparison)
         {
-            // Null/missing attributes should never satisfy comparison operators
+            // When attribute is missing, treat as 0 for numeric comparisons (matching spec behavior)
             if (attributeValue.IsNull())
             {
+                if (conditionValue.Type == JTokenType.Integer || conditionValue.Type == JTokenType.Float)
+                {
+                    var nullAttrCondNumber = conditionValue.Value<double>();
+                    return meetsComparison(((double)0).CompareTo(nullAttrCondNumber));
+                }
                 return false;
             }
 

--- a/GrowthBook/Utilities/ExperimentUtilities.cs
+++ b/GrowthBook/Utilities/ExperimentUtilities.cs
@@ -313,7 +313,7 @@ namespace GrowthBook.Utilities
 
             if (experiment.MinBucketVersion > 0)
             {
-                for(var i = 0; i <= experiment.MinBucketVersion; i++)
+                for(var i = 0; i < experiment.MinBucketVersion; i++)
                 {
                     var blockedKey = GetStickyBucketExperimentKey(experiment.Key, i);
 


### PR DESCRIPTION
This PR adds support for case-insensitive operators in the condition evaluator.

1. Adds support for case-insensitive regex operators:
- `$regexi`

- `$notRegexi`

- `$notRegex`

2. Adds case-insensitive versions of membership operators:
- `$ini `— case-insensitive version of $in

- `$nini`— case-insensitive version of $nin

- `$alli` — case-insensitive version of $all.

3. Update `standart-cases.json` file
4. Fixed bug with `minBucketVersion` doesn't allow bucketVersion of the same number through