### PR TITLE
fix: thread-safety and cache atomicity improvements

### DIFF
--- a/GrowthBook/Api/FeatureRefreshWorker.cs
+++ b/GrowthBook/Api/FeatureRefreshWorker.cs
@@ -32,8 +32,9 @@ namespace GrowthBook.Api
         private readonly IGrowthBookFeatureCache _cache;
         private readonly string _featuresApiEndpoint;
         private readonly string _serverSentEventsApiEndpoint;
-        private bool _isServerSentEventsEnabled;
+        private volatile bool _isServerSentEventsEnabled;
         private SSEClient _sseClient;
+        private readonly object _sseClientLock = new object();
         private CancellationTokenSource _refreshWorkerCancellation = new CancellationTokenSource();
 
         public FeatureRefreshWorker(ILogger<FeatureRefreshWorker> logger, IHttpClientFactory httpClientFactory, GrowthBookConfigurationOptions config, IGrowthBookFeatureCache cache)
@@ -56,7 +57,10 @@ namespace GrowthBook.Api
         public void Cancel()
         {
             _refreshWorkerCancellation.Cancel();
-            _sseClient?.Disconnect();
+            lock (_sseClientLock)
+            {
+                _sseClient?.Disconnect();
+            }
         }
 
         public async Task<IDictionary<string, Feature>> RefreshCacheFromApi(CancellationToken? cancellationToken = null)
@@ -89,20 +93,23 @@ namespace GrowthBook.Api
 
         private void EnsureCorrectRefreshModeIsActive()
         {
-            if (_isServerSentEventsEnabled)
+            lock (_sseClientLock)
             {
-                if (_sseClient == null || _sseClient.ConnectionStatus == SSEConnectionStatus.Disconnected)
+                if (_isServerSentEventsEnabled)
                 {
-                    _logger.LogDebug("Server sent events are enabled but not connected, starting SSE client now");
-                    StartSSEClient();
+                    if (_sseClient == null || _sseClient.ConnectionStatus == SSEConnectionStatus.Disconnected)
+                    {
+                        _logger.LogDebug("Server sent events are enabled but not connected, starting SSE client now");
+                        StartSSEClient();
+                    }
                 }
-            }
-            else
-            {
-                if (_sseClient != null && _sseClient.ConnectionStatus != SSEConnectionStatus.Disconnected)
+                else
                 {
-                    _logger.LogDebug("Server sent events are disabled but client is connected, disconnecting now");
-                    _sseClient.Disconnect();
+                    if (_sseClient != null && _sseClient.ConnectionStatus != SSEConnectionStatus.Disconnected)
+                    {
+                        _logger.LogDebug("Server sent events are disabled but client is connected, disconnecting now");
+                        _sseClient.Disconnect();
+                    }
                 }
             }
         }
@@ -112,22 +119,22 @@ namespace GrowthBook.Api
             try
             {
                 _sseClient?.Dispose();
-                
-                var sseLogger = _logger as ILogger<SSEClient> ?? 
+
+                var sseLogger = _logger as ILogger<SSEClient> ??
                     new Microsoft.Extensions.Logging.Abstractions.NullLogger<SSEClient>();
-                
+
                 _sseClient = new SSEClient(sseLogger, _httpClientFactory, _serverSentEventsApiEndpoint, null, ConfiguredClients.ServerSentEventsApiClient);
-                
+
                 // Add general event listener for all events (handles data field)
                 _sseClient.AddEventListener(null, async (sseEvent) =>
                 {
                     if (sseEvent.HasData)
                     {
                         _logger.LogDebug("Received SSE event: {Data}", sseEvent.Data?.Substring(0, Math.Min(sseEvent.Data?.Length ?? 0, 100)));
-                        
+
                         var features = GetFeaturesFrom(sseEvent.Data);
                         await _cache.RefreshWith(features, _refreshWorkerCancellation.Token);
-                        
+
                         _logger.LogInformation("Cache has been refreshed with server sent event features");
                     }
                 });
@@ -188,7 +195,10 @@ namespace GrowthBook.Api
         public void Dispose()
         {
             Cancel();
-            _sseClient?.Dispose();
+            lock (_sseClientLock)
+            {
+                _sseClient?.Dispose();
+            }
             _refreshWorkerCancellation?.Dispose();
         }
     }

--- a/GrowthBook/Api/FeatureRepository.cs
+++ b/GrowthBook/Api/FeatureRepository.cs
@@ -21,6 +21,7 @@ namespace GrowthBook.Api
         private readonly IRemoteEvaluationService _remoteEvaluationService;
         private readonly ConcurrentDictionary<string, ExperimentAssignment> _assigned;
         private readonly ConcurrentDictionary<string, byte> _tracked;
+        private readonly SemaphoreSlim _refreshLock = new SemaphoreSlim(1, 1);
 
         public FeatureRepository(ILogger<FeatureRepository> logger, IGrowthBookFeatureCache cache, IGrowthBookFeatureRefreshWorker backgroundRefreshWorker, IRemoteEvaluationService remoteEvaluationService = null)
         {
@@ -45,41 +46,57 @@ namespace GrowthBook.Api
             // first initialized, it should be pre-expired so that this is automatically hit
             // in order to populate the initial cache values.
 
-            if (_cache.IsCacheExpired || options?.ForceRefresh == true)
+            await _refreshLock.WaitAsync(cancellationToken ?? CancellationToken.None);
+            try
             {
-                _logger.LogInformation("Cache has expired or option to force refresh was set, refreshing the cache from the API");
-                _logger.LogDebug("Cache expired: \'{CacheIsCacheExpired}\' and option to force refresh: \'{OptionsForceRefresh}\'", _cache.IsCacheExpired, options?.ForceRefresh);
-
-                // Use TaskFactory.StartNew to decouple from the current SynchronizationContext
-                // This prevents threading issues in .NET Framework MVC when the original HttpContext
-                // thread is no longer available after the HTTP request completes
-                var taskFactory = new TaskFactory(cancellationToken ?? CancellationToken.None);
-                var refreshTask = taskFactory.StartNew(async () => await _backgroundRefreshWorker.RefreshCacheFromApi(cancellationToken)).Unwrap();
-
-                // When there aren't any features in the cache to begin with, we need to just wait until
-                // that has been officially refreshed to proceed (otherwise the caller gets nothing up front
-                // and has no way of determining when to check back). The other way to wait is if they explicitly
-                // have noted that this is something they'd like to do.
-                if (_cache.FeatureCount == 0 || options?.WaitForCompletion == true)
+                if (_cache.IsCacheExpired || options?.ForceRefresh == true)
                 {
-                    _logger.LogInformation("Either cache currently has no features or the option to wait for completion was set, waiting for cache to refresh");
-                    _logger.LogDebug("Feature count: '{CacheFeatureCount}' and option to wait for completion: '{OptionsWaitForCompletion}'", _cache.FeatureCount, options?.WaitForCompletion);
-                    return await refreshTask;
-                }
-                else
-                {
-                    // Start the refresh but don't wait - fire and forget
-                    _ = refreshTask.ContinueWith(t =>
+                    _logger.LogInformation(
+                        "Cache has expired or option to force refresh was set, refreshing the cache from the API");
+                    _logger.LogDebug(
+                        "Cache expired: \'{CacheIsCacheExpired}\' and option to force refresh: \'{OptionsForceRefresh}\'",
+                        _cache.IsCacheExpired, options?.ForceRefresh);
+
+                    // Use TaskFactory.StartNew to decouple from the current SynchronizationContext
+                    // This prevents threading issues in .NET Framework MVC when the original HttpContext
+                    // thread is no longer available after the HTTP request completes
+                    var taskFactory = new TaskFactory(cancellationToken ?? CancellationToken.None);
+                    var refreshTask = taskFactory.StartNew(async () =>
+                        await _backgroundRefreshWorker.RefreshCacheFromApi(cancellationToken)).Unwrap();
+
+                    // When there aren't any features in the cache to begin with, we need to just wait until
+                    // that has been officially refreshed to proceed (otherwise the caller gets nothing up front
+                    // and has no way of determining when to check back). The other way to wait is if they explicitly
+                    // have noted that this is something they'd like to do.
+                    if (_cache.FeatureCount == 0 || options?.WaitForCompletion == true)
                     {
-                        if (t.IsFaulted)
-                            _logger.LogError(t.Exception, "Background cache refresh failed");
-                    }, TaskContinuationOptions.OnlyOnFaulted);
+                        _logger.LogInformation(
+                            "Either cache currently has no features or the option to wait for completion was set, waiting for cache to refresh");
+                        _logger.LogDebug(
+                            "Feature count: '{CacheFeatureCount}' and option to wait for completion: '{OptionsWaitForCompletion}'",
+                            _cache.FeatureCount, options?.WaitForCompletion);
+                        return await refreshTask;
+                    }
+                    else
+                    {
+                        // Start the refresh but don't wait - fire and forget
+                        _ = refreshTask.ContinueWith(t =>
+                        {
+                            if (t.IsFaulted)
+                                _logger.LogError(t.Exception, "Background cache refresh failed");
+                        }, TaskContinuationOptions.OnlyOnFaulted);
+                    }
                 }
+
+                _logger.LogInformation(
+                    "Cache is not expired and the option to force refresh was not set, retrieving features from cache");
+
+                return await _cache.GetFeatures(cancellationToken);
             }
-
-            _logger.LogInformation("Cache is not expired and the option to force refresh was not set, retrieving features from cache");
-
-            return await _cache.GetFeatures(cancellationToken);
+            finally
+            {
+                _refreshLock.Release();
+            }
         }
 
         /// <inheritdoc/>

--- a/GrowthBook/GrowthBook.cs
+++ b/GrowthBook/GrowthBook.cs
@@ -27,6 +27,7 @@ namespace GrowthBook
     {
         private readonly bool _qaMode;
         private readonly Dictionary<string, ExperimentAssignment> _assigned;
+        private readonly object _assignedLock = new object();
         private readonly ConcurrentDictionary<string, byte> _tracked;
         private Action<Experiment, ExperimentResult> _trackingCallback;
         private bool _disposedValue;
@@ -38,6 +39,7 @@ namespace GrowthBook
         private readonly JObject _savedGroups;
         private readonly ILoggerFactory _loggerFactory;
         private readonly bool _ownsLoggerFactory;
+        private readonly bool _ownsFeatureRepository;
         private readonly Context _context;
         private JObject _previousAttributes;
         private IDictionary<string, int> _previousForcedVariations;
@@ -105,6 +107,7 @@ namespace GrowthBook
             if (context.FeatureRepository != null)
             {
                 _featureRepository = context.FeatureRepository;
+                _ownsFeatureRepository = false;
             }
             else
             {
@@ -124,6 +127,7 @@ namespace GrowthBook
                 }
 
                 _featureRepository = new FeatureRepository(featureRepositoryLogger, featureCache, featureRefreshWorker, remoteEvaluationService);
+                _ownsFeatureRepository = true;
             }
         }
 
@@ -171,11 +175,17 @@ namespace GrowthBook
                     Features.Clear();
                     ForcedVariations = null;
                     _trackingCallback = null;
-                    _assigned.Clear();
+                    lock (_assignedLock)
+                    {
+                        _assigned.Clear();
+                    }
                     _tracked.Clear();
                     _subscribers.Clear();
                     _asyncSubscribers.Clear();
-                    _featureRepository.Cancel();
+                    if (_ownsFeatureRepository)
+                    {
+                        _featureRepository.Cancel();
+                    }
 
                     if (_ownsLoggerFactory && _loggerFactory is IDisposable disposableFactory)
                     {
@@ -419,7 +429,10 @@ namespace GrowthBook
         /// <inheritdoc />
         public IDictionary<string, ExperimentAssignment> GetAllResults()
         {
-            return _assigned;
+            lock (_assignedLock)
+            {
+                return new Dictionary<string, ExperimentAssignment>(_assigned);
+            }
         }
 
         /// <inheritdoc />
@@ -689,31 +702,34 @@ namespace GrowthBook
 
         private void TryAssignExperimentResult(Experiment experiment, ExperimentResult result)
         {
-            var assignment = new ExperimentAssignment { Experiment = experiment, Result = result };
-            bool shouldFireCallbacks = false;
-
-            // Always record the assignment locally for GetAllResults()
-            if (!_assigned.TryGetValue(experiment.Key, out ExperimentAssignment prev)
-                || prev.Result.InExperiment != result.InExperiment
-                || prev.Result.VariationId != result.VariationId)
+            lock (_assignedLock)
             {
-                _assigned[experiment.Key] = assignment;
-                shouldFireCallbacks = true;
-            }
+                var assignment = new ExperimentAssignment { Experiment = experiment, Result = result };
+                bool shouldFireCallbacks = false;
 
-            // Also use repository tracking if available (for preventing duplicate callbacks across instances)
-            if (_featureRepository != null)
-            {
-                if (!_featureRepository.HasIdenticalAssignment(experiment.Key, assignment))
+                // Always record the assignment locally for GetAllResults()
+                if (!_assigned.TryGetValue(experiment.Key, out ExperimentAssignment prev)
+                    || prev.Result.InExperiment != result.InExperiment
+                    || prev.Result.VariationId != result.VariationId)
                 {
-                    _featureRepository.RecordAssignment(experiment.Key, assignment);
+                    _assigned[experiment.Key] = assignment;
+                    shouldFireCallbacks = true;
                 }
-            }
 
-            // Fire subscription callbacks if needed
-            if (shouldFireCallbacks)
-            {
-                NotifySubscribers(experiment, result);
+                // Also use repository tracking if available (for preventing duplicate callbacks across instances)
+                if (_featureRepository != null)
+                {
+                    if (!_featureRepository.HasIdenticalAssignment(experiment.Key, assignment))
+                    {
+                        _featureRepository.RecordAssignment(experiment.Key, assignment);
+                    }
+                }
+
+                // Fire subscription callbacks if needed
+                if (shouldFireCallbacks)
+                {
+                    NotifySubscribers(experiment, result);
+                }
             }
         }
 

--- a/GrowthBook/Providers/ConditionEvaluationProvider.cs
+++ b/GrowthBook/Providers/ConditionEvaluationProvider.cs
@@ -551,7 +551,7 @@ namespace GrowthBook.Providers
             {
                 attrNumber = attributeValue.Value<double>();
             }
-            else if (!double.TryParse(attributeValue.ToString(), out attrNumber))
+            else if (!double.TryParse(attributeValue.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out attrNumber))
             {
                 return false;
             }
@@ -560,7 +560,7 @@ namespace GrowthBook.Providers
             {
                 condNumber = conditionValue.Value<double>();
             }
-            else if (!double.TryParse(conditionValue.ToString(), out condNumber))
+            else if (!double.TryParse(conditionValue.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out condNumber))
             {
                 return false;
             }

--- a/GrowthBook/Services/InMemoryStickyBucketService.cs
+++ b/GrowthBook/Services/InMemoryStickyBucketService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -7,7 +8,7 @@ namespace GrowthBook.Services
 {
     public class InMemoryStickyBucketService : IStickyBucketService
     {
-        private readonly IDictionary<string, StickyAssignmentsDocument> _cachedDocuments = new Dictionary<string, StickyAssignmentsDocument>();
+        private readonly ConcurrentDictionary<string, StickyAssignmentsDocument> _cachedDocuments = new ConcurrentDictionary<string, StickyAssignmentsDocument>();
 
         public IDictionary<string, StickyAssignmentsDocument> GetAllAssignments(IEnumerable<string> attributes)
         {


### PR DESCRIPTION
## Problem
Several thread-safety and atomicity issues were identified in the caching layer that could cause race conditions under concurrent load.

## Changes                                                                                                                                                                        
- **FeatureRepository**: added `SemaphoreSlim _refreshLock` to prevent multiple concurrent API refreshes (TOCTOU race condition)
- **InMemoryStickyBucketService**: replaced `Dictionary` with `ConcurrentDictionary` to ensure thread-safe reads and writes
- **FeatureRefreshWorker**: marked `_isServerSentEventsEnabled` as `volatile` to ensure visibility across threads; added `lock _sseClientLock` around all `_sseClient` access to prevent duplicate SSE connections and memory leaks 
- **GrowthBook**: added `lock _assignedLock` around `_assigned` dictionary access; `GetAllResults()` now returns a copy instead of the internal dictionary; added `_ownsFeatureRepository` flag so `Dispose()` does not cancel a shared Singleton `FeatureRepository`   
 - **ConditionEvaluationProvider**: fixed numeric parsing in `TryParseNumbers`to use `CultureInfo.InvariantCulture` and `NumberStyles.Any`, preventing incorrect comparisons on servers with non-English locale settings;