### PR TITLE
feat: add plugin system with built-in tracking plugin

### DIFF
--- a/GrowthBook.Tests/CustomTests/GrowthBookTrackingPluginTests.cs
+++ b/GrowthBook.Tests/CustomTests/GrowthBookTrackingPluginTests.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GrowthBook.Plugin;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GrowthBook.Tests.CustomTests
+{
+    public class GrowthBookTrackingPluginTests
+    {
+        private class CapturingHandler : HttpMessageHandler
+        {
+            private readonly CountdownEvent _latch;
+            private readonly HttpStatusCode _statusCode;
+            public List<JArray> Posts { get; } = new List<JArray>();
+
+            public CapturingHandler(int expectedPosts = 1, HttpStatusCode statusCode = HttpStatusCode.OK)
+            {
+                _latch = new CountdownEvent(expectedPosts);
+                _statusCode = statusCode;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var body = await request.Content.ReadAsStringAsync();
+                var json = JToken.Parse(body);
+                if (json is JArray array)
+                    lock (Posts) Posts.Add(array);
+
+                if (_latch.CurrentCount > 0)
+                    _latch.Signal();
+
+                return new HttpResponseMessage(_statusCode);
+            }
+
+            public JArray WaitForPost(int timeoutSeconds = 5)
+            {
+                _latch.Wait(TimeSpan.FromSeconds(timeoutSeconds));
+                lock (Posts) return Posts.Count > 0 ? Posts[0] : null;
+            }
+
+            public bool ReceivedNoPost(int timeoutMs = 500) =>
+                !_latch.Wait(TimeSpan.FromMilliseconds(timeoutMs));
+
+            public string LastUrl { get; private set; }
+
+            protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken) =>
+                throw new NotSupportedException();
+        }
+
+        private static Experiment MakeExperiment(string key) => new Experiment { Key = key };
+
+        private static ExperimentResult MakeExperimentResult(int variation = 0) => new ExperimentResult
+        {
+            VariationId = variation,
+            HashAttribute = "id",
+            HashValue = $"u-{variation}",
+        };
+
+        private static FeatureResult MakeFeatureResult() => new FeatureResult
+        {
+            Value = new JValue("v"),
+            Source = FeatureResult.SourceId.DefaultValue,
+        };
+
+        [Fact]
+        public void FlushesWhenBatchSizeReached()
+        {
+            var handler = new CapturingHandler(expectedPosts: 1);
+            var plugin = new GrowthBookTrackingPlugin(new TrackingPluginConfig
+            {
+                ClientKey = "sdk-test",
+                HttpClient = new HttpClient(handler),
+                BatchSize = 2,
+                BatchTimeout = TimeSpan.FromSeconds(30),
+            });
+            plugin.Init();
+
+            plugin.OnExperimentViewed(MakeExperiment("exp1"), MakeExperimentResult(0), null);
+            plugin.OnExperimentViewed(MakeExperiment("exp2"), MakeExperimentResult(1), null);
+
+            var events = handler.WaitForPost();
+            events.Should().NotBeNull("should flush when batch size is reached");
+            events.Count.Should().Be(2);
+
+            var experimentIds = events
+                .Select(e => e["properties"]?["experimentId"]?.Value<string>())
+                .ToList();
+            experimentIds.Should().Contain("exp1");
+            experimentIds.Should().Contain("exp2");
+
+            plugin.Close();
+        }
+
+        [Fact]
+        public void FlushesWhenTimerFires()
+        {
+            var handler = new CapturingHandler(expectedPosts: 1);
+            var plugin = new GrowthBookTrackingPlugin(new TrackingPluginConfig
+            {
+                ClientKey = "sdk-test",
+                HttpClient = new HttpClient(handler),
+                BatchSize = 100,
+                BatchTimeout = TimeSpan.FromMilliseconds(200),
+            });
+            plugin.Init();
+
+            plugin.OnFeatureEvaluated("flag1", MakeFeatureResult(), null);
+
+            var events = handler.WaitForPost(timeoutSeconds: 5);
+            events.Should().NotBeNull("timer-based flush should fire within 5s");
+            events.Count.Should().Be(1);
+            events[0]["event_name"]?.Value<string>().Should().Be(TrackingEvent.EventFeatureEvaluated);
+            events[0]["properties"]?["feature"]?.Value<string>().Should().Be("flag1");
+
+            plugin.Close();
+        }
+
+        [Fact]
+        public void CloseFlushesRemainingEvents()
+        {
+            var handler = new CapturingHandler(expectedPosts: 1);
+            var plugin = new GrowthBookTrackingPlugin(new TrackingPluginConfig
+            {
+                ClientKey = "sdk-test",
+                HttpClient = new HttpClient(handler),
+                BatchSize = 100,
+                BatchTimeout = TimeSpan.FromSeconds(60),
+            });
+            plugin.Init();
+
+            plugin.OnExperimentViewed(MakeExperiment("exp"), MakeExperimentResult(), null);
+            plugin.Close();
+
+            var events = handler.WaitForPost();
+            events.Should().NotBeNull("Close() should flush remaining events");
+            events.Count.Should().Be(1);
+        }
+
+        [Fact]
+        public void CloseIsIdempotent()
+        {
+            var handler = new CapturingHandler();
+            var plugin = new GrowthBookTrackingPlugin(new TrackingPluginConfig
+            {
+                ClientKey = "sdk-test",
+                HttpClient = new HttpClient(handler),
+            });
+
+            var act = () =>
+            {
+                plugin.Close();
+                plugin.Close();
+            };
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void NullClientKeyDisablesPlugin()
+        {
+            var handler = new CapturingHandler();
+            var plugin = new GrowthBookTrackingPlugin(new TrackingPluginConfig
+            {
+                ClientKey = null,
+                HttpClient = new HttpClient(handler),
+                BatchSize = 1,
+            });
+            plugin.Init();
+
+            plugin.OnExperimentViewed(MakeExperiment("exp"), MakeExperimentResult(), null);
+            plugin.OnFeatureEvaluated("flag", MakeFeatureResult(), null);
+            plugin.Close();
+
+            handler.ReceivedNoPost().Should().BeTrue("null clientKey must disable the plugin");
+        }
+
+        [Fact]
+        public void EmptyClientKeyDisablesPlugin()
+        {
+            var handler = new CapturingHandler();
+            var plugin = new GrowthBookTrackingPlugin(new TrackingPluginConfig
+            {
+                ClientKey = "",
+                HttpClient = new HttpClient(handler),
+                BatchSize = 1,
+            });
+            plugin.Init();
+
+            plugin.OnFeatureEvaluated("flag", MakeFeatureResult(), null);
+            plugin.Close();
+
+            handler.ReceivedNoPost().Should().BeTrue("empty clientKey must disable the plugin");
+        }
+
+        [Fact]
+        public void HttpErrorDoesNotThrow()
+        {
+            var handler = new CapturingHandler(statusCode: HttpStatusCode.InternalServerError);
+            var plugin = new GrowthBookTrackingPlugin(new TrackingPluginConfig
+            {
+                ClientKey = "sdk-test",
+                HttpClient = new HttpClient(handler),
+                BatchSize = 1,
+            });
+            plugin.Init();
+
+            var act = () =>
+            {
+                plugin.OnExperimentViewed(MakeExperiment("exp"), MakeExperimentResult(), null);
+                handler.WaitForPost();
+                plugin.Close();
+            };
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void IngestorHostTrailingSlashIsStripped()
+        {
+            var config = new TrackingPluginConfig
+            {
+                IngestorHost = "https://example.test/",
+                ClientKey = "k",
+            };
+
+            config.ResolvedIngestorHost().Should().Be("https://example.test");
+            config.ResolvedIngestorHost().Should().NotEndWith("/");
+        }
+
+        [Fact]
+        public void DefaultIngestorHostIsUsedWhenNotSet()
+        {
+            var config = new TrackingPluginConfig { ClientKey = "k" };
+            config.ResolvedIngestorHost().Should().Be(TrackingPluginConfig.DefaultIngestorHost);
+        }
+
+        [Fact]
+        public void SdkMetadataVersionIsNotEmpty()
+        {
+            SdkMetadata.Version.Should().NotBeNullOrEmpty();
+            SdkMetadata.Version.Should().NotBe("unknown");
+        }
+
+        [Fact]
+        public void AttributesAreIncludedInEvent()
+        {
+            var handler = new CapturingHandler();
+            var plugin = new GrowthBookTrackingPlugin(new TrackingPluginConfig
+            {
+                ClientKey = "sdk-test",
+                HttpClient = new HttpClient(handler),
+                BatchSize = 1,
+            });
+            plugin.Init();
+
+            var attrs = new JObject { ["id"] = "u1", ["plan"] = "pro" };
+            plugin.OnFeatureEvaluated("flag", MakeFeatureResult(), attrs);
+
+            var events = handler.WaitForPost();
+            events.Should().NotBeNull();
+
+            var eventAttrs = events[0]["attributes"] as JObject;
+            eventAttrs.Should().NotBeNull("attributes should be present in event");
+            eventAttrs["id"]?.Value<string>().Should().Be("u1");
+            eventAttrs["plan"]?.Value<string>().Should().Be("pro");
+
+            plugin.Close();
+        }
+
+        [Fact]
+        public void SdkAttributesAreMergedIntoEvent()
+        {
+            var handler = new CapturingHandler();
+            var plugin = new GrowthBookTrackingPlugin(new TrackingPluginConfig
+            {
+                ClientKey = "sdk-test",
+                HttpClient = new HttpClient(handler),
+                BatchSize = 1,
+            });
+            plugin.Init();
+            plugin.OnFeatureEvaluated("flag", MakeFeatureResult(), null);
+
+            var events = handler.WaitForPost();
+            events.Should().NotBeNull();
+
+            var attrs = events[0]["attributes"] as JObject;
+            attrs.Should().NotBeNull();
+            attrs["sdk_language"]?.Value<string>().Should().Be(SdkMetadata.Language);
+            attrs["sdk_version"]?.Value<string>().Should().Be(SdkMetadata.Version);
+
+            plugin.Close();
+        }
+
+        [Fact]
+        public void BodyIsPlainJsonArray()
+        {
+            var handler = new CapturingHandler();
+            var plugin = new GrowthBookTrackingPlugin(new TrackingPluginConfig
+            {
+                ClientKey = "sdk-test",
+                HttpClient = new HttpClient(handler),
+                BatchSize = 1,
+            });
+            plugin.Init();
+            plugin.OnFeatureEvaluated("flag", MakeFeatureResult(), null);
+
+            var events = handler.WaitForPost();
+            events.Should().NotBeNull();
+            events.Should().BeOfType<JArray>("body must be a plain JSON array, not a wrapped object");
+
+            plugin.Close();
+        }
+
+        [Fact]
+        public void PostUrlUsesTrackEndpointWithClientKey()
+        {
+            string capturedUrl = null;
+            var latch = new CountdownEvent(1);
+
+            var handler = new CapturingUrlHandler(url =>
+            {
+                capturedUrl = url;
+                latch.Signal();
+            });
+
+            var plugin = new GrowthBookTrackingPlugin(new TrackingPluginConfig
+            {
+                IngestorHost = "https://ingest.example.com",
+                ClientKey = "k",
+                HttpClient = new HttpClient(handler),
+                BatchSize = 1,
+            });
+            plugin.Init();
+            plugin.OnFeatureEvaluated("flag", MakeFeatureResult(), null);
+
+            latch.Wait(TimeSpan.FromSeconds(5));
+            capturedUrl.Should().Be("https://ingest.example.com/track?client_key=k");
+
+            plugin.Close();
+        }
+
+        private class CapturingUrlHandler : HttpMessageHandler
+        {
+            private readonly Action<string> _onRequest;
+
+            public CapturingUrlHandler(Action<string> onRequest) => _onRequest = onRequest;
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                _onRequest(request.RequestUri.ToString());
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+        }
+    }
+}

--- a/GrowthBook.Tests/CustomTests/PluginIntegrationTests.cs
+++ b/GrowthBook.Tests/CustomTests/PluginIntegrationTests.cs
@@ -1,0 +1,185 @@
+using System.Collections.Generic;
+using System.Threading;
+using FluentAssertions;
+using GrowthBook.Plugin;
+using Microsoft.Extensions.Logging.Abstractions;
+using GrowthBookSdk = GrowthBook;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GrowthBook.Tests.CustomTests
+{
+    public class PluginIntegrationTests
+    {
+        private class RecordingPlugin : IGrowthBookPlugin
+        {
+            public List<(Experiment Experiment, ExperimentResult Result)> Experiments { get; } = new List<(Experiment, ExperimentResult)>();
+            public List<(string Key, FeatureResult Result)> Features { get; } = new List<(string, FeatureResult)>();
+            public int InitCount;
+            public int CloseCount;
+
+            public void Init() => Interlocked.Increment(ref InitCount);
+            public void OnExperimentViewed(Experiment e, ExperimentResult r, JObject a) { lock (Experiments) Experiments.Add((e, r)); }
+            public void OnFeatureEvaluated(string k, FeatureResult r, JObject a) { lock (Features) Features.Add((k, r)); }
+            public void Close() => Interlocked.Increment(ref CloseCount);
+        }
+
+        private class ThrowingPlugin : IGrowthBookPlugin
+        {
+            public void Init() { }
+            public void OnExperimentViewed(Experiment e, ExperimentResult r, JObject a) => throw new System.Exception("plugin error");
+            public void OnFeatureEvaluated(string k, FeatureResult r, JObject a) => throw new System.Exception("plugin error");
+            public void Close() { }
+        }
+
+        private static GrowthBookSdk.GrowthBook BuildGrowthBook(List<IGrowthBookPlugin> plugins)
+        {
+            return new GrowthBookSdk.GrowthBook(new Context
+            {
+                Enabled = true,
+                Attributes = new JObject { ["id"] = "u1", ["tier"] = "gold" },
+                Features = new Dictionary<string, Feature>
+                {
+                    ["flag-a"] = new Feature { DefaultValue = JToken.FromObject(true) },
+                    ["flag-b"] = new Feature { DefaultValue = JToken.FromObject("x") },
+                },
+                LoggerFactory = NullLoggerFactory.Instance,
+                Plugins = plugins,
+            });
+        }
+
+        [Fact]
+        public void PluginInitCalledOnConstruction()
+        {
+            var plugin = new RecordingPlugin();
+            using var gb = BuildGrowthBook(new List<IGrowthBookPlugin> { plugin });
+
+            plugin.InitCount.Should().Be(1, "Init() must be called exactly once on construction");
+        }
+
+        [Fact]
+        public void PluginObservesFeatureEvaluation()
+        {
+            var plugin = new RecordingPlugin();
+            using var gb = BuildGrowthBook(new List<IGrowthBookPlugin> { plugin });
+
+            gb.EvalFeature("flag-a");
+            gb.EvalFeature("flag-b");
+
+            plugin.Features.Should().HaveCountGreaterOrEqualTo(2);
+            plugin.Features.Should().Contain(f => f.Key == "flag-a");
+            plugin.Features.Should().Contain(f => f.Key == "flag-b");
+        }
+
+        [Fact]
+        public void PluginObservesExperimentViewed()
+        {
+            var plugin = new RecordingPlugin();
+            using var gb = new GrowthBookSdk.GrowthBook(new Context
+            {
+                Enabled = true,
+                Attributes = new JObject { ["id"] = "u1" },
+                Features = new Dictionary<string, Feature>
+                {
+                    ["flag-a"] = new Feature { DefaultValue = JToken.FromObject(true) },
+                },
+                LoggerFactory = NullLoggerFactory.Instance,
+                Plugins = new List<IGrowthBookPlugin> { plugin },
+                TrackingCallback = (e, r) => { },
+            });
+
+            var experiment = new Experiment
+            {
+                Key = "my-exp",
+                Variations = JArray.Parse("[\"A\", \"B\"]"),
+            };
+
+            var result = gb.Run(experiment);
+
+            if (result.InExperiment)
+                plugin.Experiments.Should().HaveCount(1, "plugin should see experiment event exactly once");
+        }
+
+        [Fact]
+        public void PluginCloseCalledOnDispose()
+        {
+            var plugin = new RecordingPlugin();
+            var gb = BuildGrowthBook(new List<IGrowthBookPlugin> { plugin });
+
+            gb.Dispose();
+
+            plugin.CloseCount.Should().Be(1, "Close() should fire when GrowthBook is disposed");
+        }
+
+        [Fact]
+        public void MultiplePluginsEachReceiveEvents()
+        {
+            var first = new RecordingPlugin();
+            var second = new RecordingPlugin();
+            using var gb = BuildGrowthBook(new List<IGrowthBookPlugin> { first, second });
+
+            gb.EvalFeature("flag-a");
+
+            first.Features.Should().HaveCountGreaterOrEqualTo(1);
+            second.Features.Count.Should().Be(first.Features.Count, "both plugins should receive the same number of events");
+        }
+
+        [Fact]
+        public void ThrowingPluginDoesNotBreakEvaluation()
+        {
+            var bad = new ThrowingPlugin();
+            using var gb = BuildGrowthBook(new List<IGrowthBookPlugin> { bad });
+
+            var result = gb.EvalFeature("flag-a");
+
+            result.On.Should().BeTrue("feature evaluation should succeed despite throwing plugin");
+        }
+
+        [Fact]
+        public void PluginReceivesFeatureEventWithoutTrackingCallback()
+        {
+            var plugin = new RecordingPlugin();
+            using var gb = new GrowthBookSdk.GrowthBook(new Context
+            {
+                Enabled = true,
+                Attributes = new JObject { ["id"] = "u1" },
+                Features = new Dictionary<string, Feature>
+                {
+                    ["flag-a"] = new Feature { DefaultValue = JToken.FromObject(true) },
+                },
+                LoggerFactory = NullLoggerFactory.Instance,
+                Plugins = new List<IGrowthBookPlugin> { plugin },
+                // TrackingCallback = null навмисно
+            });
+
+            gb.EvalFeature("flag-a");
+
+            plugin.Features.Should().Contain(f => f.Key == "flag-a",
+                "plugin should observe feature evaluation even without TrackingCallback");
+        }
+
+        [Fact]
+        public void AttributesArePassedToPlugin()
+        {
+            JObject receivedAttributes = null;
+            var plugin = new CapturingAttributesPlugin(attrs => receivedAttributes = attrs);
+
+            using var gb = BuildGrowthBook(new List<IGrowthBookPlugin> { plugin });
+            gb.EvalFeature("flag-a");
+
+            receivedAttributes.Should().NotBeNull();
+            receivedAttributes["id"]?.Value<string>().Should().Be("u1");
+            receivedAttributes["tier"]?.Value<string>().Should().Be("gold");
+        }
+
+        private class CapturingAttributesPlugin : IGrowthBookPlugin
+        {
+            private readonly System.Action<JObject> _onFeature;
+            public CapturingAttributesPlugin(System.Action<JObject> onFeature) => _onFeature = onFeature;
+            public void Init() { }
+            public void OnExperimentViewed(Experiment e, ExperimentResult r, JObject a) { }
+            public void OnFeatureEvaluated(string k, FeatureResult r, JObject a) => _onFeature(a);
+            public void Close() { }
+        }
+    }
+}

--- a/GrowthBook.Tests/CustomTests/PluginRegistryTests.cs
+++ b/GrowthBook.Tests/CustomTests/PluginRegistryTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using FluentAssertions;
+using GrowthBook.Plugin;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GrowthBook.Tests.CustomTests
+{
+    public class PluginRegistryTests
+    {
+        private static Experiment MakeExperiment() => new Experiment { Key = "e" };
+        private static ExperimentResult MakeExperimentResult() => new ExperimentResult();
+        private static FeatureResult MakeFeatureResult() => new FeatureResult { Source = FeatureResult.SourceId.DefaultValue };
+
+        private class CountingPlugin : IGrowthBookPlugin
+        {
+            public int InitCount;
+            public int ExperimentCount;
+            public int FeatureCount;
+            public int CloseCount;
+
+            public void Init() => Interlocked.Increment(ref InitCount);
+            public void OnExperimentViewed(Experiment e, ExperimentResult r, JObject a) => Interlocked.Increment(ref ExperimentCount);
+            public void OnFeatureEvaluated(string k, FeatureResult r, JObject a) => Interlocked.Increment(ref FeatureCount);
+            public void Close() => Interlocked.Increment(ref CloseCount);
+        }
+
+        private class ThrowingPlugin : IGrowthBookPlugin
+        {
+            public void Init() => throw new Exception("boom");
+            public void OnExperimentViewed(Experiment e, ExperimentResult r, JObject a) => throw new Exception("boom");
+            public void OnFeatureEvaluated(string k, FeatureResult r, JObject a) => throw new Exception("boom");
+            public void Close() => throw new Exception("boom");
+        }
+
+        [Fact]
+        public void DispatchesToEachPlugin()
+        {
+            var p1 = new CountingPlugin();
+            var p2 = new CountingPlugin();
+            var registry = new PluginRegistry(new List<IGrowthBookPlugin> { p1, p2 });
+
+            registry.InitAll();
+            registry.FireExperimentViewed(MakeExperiment(), MakeExperimentResult(), null);
+            registry.FireFeatureEvaluated("f", MakeFeatureResult(), null);
+            registry.CloseAll();
+
+            p1.InitCount.Should().Be(1);
+            p1.ExperimentCount.Should().Be(1);
+            p1.FeatureCount.Should().Be(1);
+            p1.CloseCount.Should().Be(1);
+
+            p2.InitCount.Should().Be(1);
+            p2.ExperimentCount.Should().Be(1);
+            p2.FeatureCount.Should().Be(1);
+            p2.CloseCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void OnePluginThrowingDoesNotStopOthers()
+        {
+            var good = new CountingPlugin();
+            var registry = new PluginRegistry(new List<IGrowthBookPlugin> { new ThrowingPlugin(), good });
+
+            registry.InitAll();
+            registry.FireExperimentViewed(MakeExperiment(), MakeExperimentResult(), null);
+            registry.FireFeatureEvaluated("f", MakeFeatureResult(), null);
+            registry.CloseAll();
+
+            good.InitCount.Should().Be(1);
+            good.ExperimentCount.Should().Be(1);
+            good.FeatureCount.Should().Be(1);
+            good.CloseCount.Should().Be(1, "good plugin should receive all 4 lifecycle events");
+        }
+
+        [Fact]
+        public void EmptyRegistryIsNoOp()
+        {
+            var registry = new PluginRegistry(new List<IGrowthBookPlugin>());
+
+            var act = () =>
+            {
+                registry.InitAll();
+                registry.FireExperimentViewed(MakeExperiment(), MakeExperimentResult(), null);
+                registry.FireFeatureEvaluated("f", MakeFeatureResult(), null);
+                registry.CloseAll();
+            };
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void NullPluginListIsNoOp()
+        {
+            var registry = new PluginRegistry(null);
+
+            var act = () =>
+            {
+                registry.InitAll();
+                registry.CloseAll();
+            };
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void IsEmptyReturnsTrueForEmptyList()
+        {
+            var registry = new PluginRegistry(new List<IGrowthBookPlugin>());
+            registry.IsEmpty.Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsEmptyReturnsFalseWhenPluginsExist()
+        {
+            var registry = new PluginRegistry(new List<IGrowthBookPlugin> { new CountingPlugin() });
+            registry.IsEmpty.Should().BeFalse();
+        }
+    }
+}

--- a/GrowthBook/Context.cs
+++ b/GrowthBook/Context.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using GrowthBook.Plugin;
 using GrowthBook.Services;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -129,6 +130,11 @@ namespace GrowthBook
         public IGrowthBookFeatureRepository FeatureRepository { get; set; }
 
         /// <summary>
+        /// Optional list of plugins to receive experiment and feature evaluation events.
+        /// </summary>
+        public List<IGrowthBookPlugin> Plugins { get; set; }
+
+        /// <summary>
         /// A logger factory implementation that will enable logging throughout the SDK. Optional.
         /// </summary>
         public ILoggerFactory LoggerFactory { get; set; }
@@ -195,6 +201,7 @@ namespace GrowthBook
                 SavedGroups = this.SavedGroups?.DeepClone() as JObject,
                 QaMode = this.QaMode,
                 TrackingCallback = this.TrackingCallback,
+                Plugins = this.Plugins?.ToList(),
                 FeatureRepository = this.FeatureRepository,
                 LoggerFactory = this.LoggerFactory,
                 CachePath = this.CachePath,

--- a/GrowthBook/GrowthBook.cs
+++ b/GrowthBook/GrowthBook.cs
@@ -12,6 +12,7 @@ using GrowthBook.Providers;
 using GrowthBook.Services;
 using GrowthBook.Utilities;
 using GrowthBook.Exceptions;
+using GrowthBook.Plugin;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -35,6 +36,7 @@ namespace GrowthBook
         private readonly IStickyBucketService _stickyBucketService;
         private readonly IDictionary<string, StickyAssignmentsDocument> _stickyBucketAssignmentDocs;
         private readonly ILogger<GrowthBook> _logger;
+        private readonly PluginRegistry _pluginRegistry;
         private readonly JObject _savedGroups;
         private readonly ILoggerFactory _loggerFactory;
         private readonly bool _ownsLoggerFactory;
@@ -99,6 +101,9 @@ namespace GrowthBook
 
             _logger = _loggerFactory.CreateLogger<GrowthBook>();
             var conditionEvaluatorLogger = _loggerFactory.CreateLogger<ConditionEvaluationProvider>();
+
+            _pluginRegistry = new PluginRegistry(context.Plugins, _logger);
+            _pluginRegistry.InitAll();
 
             _conditionEvaluator = new ConditionEvaluationProvider(conditionEvaluatorLogger);
 
@@ -176,6 +181,7 @@ namespace GrowthBook
                     _subscribers.Clear();
                     _asyncSubscribers.Clear();
                     _featureRepository.Cancel();
+                    _pluginRegistry.CloseAll();
 
                     if (_ownsLoggerFactory && _loggerFactory is IDisposable disposableFactory)
                     {
@@ -429,15 +435,17 @@ namespace GrowthBook
             {
                 LoadFeatures().GetAwaiter().GetResult();
             }
-
-            return EvaluateFeature(featureId);
+            var result = EvaluateFeature(featureId);
+            _pluginRegistry.FireFeatureEvaluated(featureId, result, Attributes);
+            return result;
         }
 
         public async Task<FeatureResult> EvalFeatureAsync(string featureId, CancellationToken? cancellationToken = null)
         {
             await LoadFeatures(cancellationToken: cancellationToken);
-
-            return EvaluateFeature(featureId);
+            var result = EvaluateFeature(featureId);
+            _pluginRegistry.FireFeatureEvaluated(featureId, result, Attributes);
+            return result;
         }
 
         private FeatureResult EvaluateFeature(string featureId, ISet<string> evaluatedFeatures = default)
@@ -527,13 +535,14 @@ namespace GrowthBook
                             continue;
                         }
 
-                        if (_trackingCallback != null && rule.Tracks?.Any() == true)
+                        if (rule.Tracks?.Any() == true)
                         {
                             foreach (var trackData in rule.Tracks)
                             {
                                 try
                                 {
                                     _trackingCallback?.Invoke(trackData.Experiment, trackData.Result);
+                                    _pluginRegistry.FireExperimentViewed(trackData.Experiment, trackData.Result, Attributes);
                                 }
                                 catch (Exception ex)
                                 {
@@ -1078,10 +1087,6 @@ namespace GrowthBook
         /// <param name="result">The result of the assignment.</param>
         private void TryToTrack(Experiment experiment, ExperimentResult result)
         {
-            if (_trackingCallback == null)
-            {
-                return;
-            }
 
             string key = result.HashAttribute + result.HashValue + experiment.Key + result.VariationId;
 
@@ -1101,14 +1106,19 @@ namespace GrowthBook
 
             if (shouldTrack)
             {
-                try
+                if (_trackingCallback != null)
                 {
-                    _trackingCallback(experiment, result);
+                    try
+                    {
+                        _trackingCallback(experiment, result);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Encountered unhandled exception during tracking callback for experiment with combined key \'{Key}\'", key);
+                    }
                 }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Encountered unhandled exception during tracking callback for experiment with combined key \'{Key}\'", key);
-                }
+                _pluginRegistry.FireExperimentViewed(experiment, result, Attributes);
+
             }
         }
 

--- a/GrowthBook/Plugin/Tracking/GrowthBookTrackingPlugin.cs
+++ b/GrowthBook/Plugin/Tracking/GrowthBookTrackingPlugin.cs
@@ -1,0 +1,201 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace GrowthBook.Plugin
+{
+    /// <summary>
+    /// An <see cref="IGrowthBookPlugin"/> that batches experiment and feature evaluation events
+    /// and posts them to the GrowthBook ingestor endpoint.
+    /// <para>
+    /// Events are flushed either when the batch reaches <see cref="TrackingPluginConfig.BatchSize"/>
+    /// or when <see cref="TrackingPluginConfig.BatchTimeout"/> elapses, whichever comes first.
+    /// All remaining events are flushed synchronously on <see cref="Close"/>.
+    /// </para>
+    /// <para>
+    /// The plugin is disabled (no HTTP calls are made) when <see cref="TrackingPluginConfig.ClientKey"/>
+    /// is null or empty.
+    /// </para>
+    /// </summary>
+    public sealed class GrowthBookTrackingPlugin: IGrowthBookPlugin
+    {
+        private readonly TrackingPluginConfig _config;
+        private readonly HttpClient _httpClient;
+        private readonly bool _ownsHttpClient;
+        private readonly bool _disabled;
+        private readonly ILogger _logger;
+
+        private readonly object _lock = new object();
+        private readonly List<TrackingEvent> _buffer = new List<TrackingEvent>();
+        private Timer _timer;
+        private volatile bool _closed;
+
+        public GrowthBookTrackingPlugin(TrackingPluginConfig config, ILogger logger = null)
+        {
+            _config = config;
+            _logger = logger;
+            _disabled = string.IsNullOrEmpty(config.ClientKey);
+
+            if (config.HttpClient != null)
+            {
+                _httpClient = config.HttpClient;
+                _ownsHttpClient = false;
+            }
+            else
+            {
+                _httpClient = new HttpClient();
+                _ownsHttpClient = true;
+            }
+        }
+
+
+        public void Init()
+        {
+            if (_disabled)
+            {
+                _logger?.LogWarning("GrowthBookTrackingPlugin is disabled");
+            }
+        }
+
+        public void OnExperimentViewed(Experiment experiment, ExperimentResult result, JObject attributes)
+        {
+            if (_disabled || _closed) return;
+
+            Enqueue(TrackingEvent.ForExperiment(experiment, result, attributes));
+        }
+
+        public void OnFeatureEvaluated(string featureKey, FeatureResult result, JObject attributes)
+        {
+            if (_disabled || _closed) return;
+
+            Enqueue(TrackingEvent.ForFeature(featureKey, result, attributes));
+        }
+
+        public void Close()
+        {
+            List<TrackingEvent> toFlush;
+            lock (_lock)
+            {
+                if (_closed) return;
+                _closed = true;
+
+                _timer?.Dispose();
+                _timer = null;
+
+                toFlush = DrainBuffer();
+            }
+
+            if (toFlush.Count > 0)
+            {
+                try
+                {
+                    FlushBatch(toFlush);
+                }
+                catch (System.Exception ex)
+                {
+                    _logger?.LogWarning(ex, "Final tracking flush failed: {Message}", ex.Message);
+                }
+            }
+
+            if (_ownsHttpClient)
+            {
+                _httpClient.Dispose();
+            }
+        }
+
+        private void Enqueue(TrackingEvent trackingEvent)
+        {
+            List<TrackingEvent> eagerFlush = null;
+
+            lock (_lock)
+            {
+                _buffer.Add(trackingEvent);
+
+                if (_buffer.Count >= _config.ResolvedBatchSize())
+                {
+                    _timer?.Dispose();
+                    _timer = null;
+                    eagerFlush = DrainBuffer();
+                } else if (_timer == null)
+                {
+                    var timeout = _config.ResolvedBatchTimeout();
+                    _timer = new Timer(ScheduledFlush, null, timeout, Timeout.InfiniteTimeSpan);
+                }
+            }
+
+            if (eagerFlush != null)
+            {
+                Task.Run(() =>
+                {
+                    try
+                    {
+                        FlushBatch(eagerFlush);
+                    }
+                    catch (System.Exception ex)
+                    {
+                        _logger?.LogWarning(ex, "Tracking flush failed: {Message}", ex.Message);
+                    }
+                });
+            }
+        }
+
+        private List<TrackingEvent> DrainBuffer()
+        {
+           var result = new List<TrackingEvent>(_buffer);
+           _buffer.Clear();
+           return result;
+        }
+
+        private void ScheduledFlush(object state)
+        {
+            if (_closed) return;
+
+            List<TrackingEvent> toFlush;
+            lock (_lock)
+            {
+                _timer = null;
+                toFlush = DrainBuffer();
+            }
+
+            if (toFlush.Count > 0)
+            {
+                Task.Run(() =>
+                    {
+                        try
+                        {
+                            FlushBatch(toFlush);
+                        }
+                        catch (System.Exception ex)
+                        {
+                            _logger?.LogWarning(ex, "Tracking flush failed: {Message}", ex.Message);
+                        }
+                    }
+                );
+            }
+        }
+
+        private void FlushBatch(List<TrackingEvent> batch)
+        {
+            if (batch.Count == 0 || _disabled) return;
+
+            var url = $"{_config.ResolvedIngestorHost()}/track?client_key={_config.ClientKey}";
+            var json = JsonConvert.SerializeObject(batch);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            var request = new HttpRequestMessage(HttpMethod.Post, url) { Content = content };
+            request.Headers.TryAddWithoutValidation("User-Agent", SdkMetadata.UserAgent);
+
+            var response = _httpClient.SendAsync(request).GetAwaiter().GetResult();
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger?.LogWarning("Tracking POST {Url} returned {Status}", url, (int)response.StatusCode);
+            }
+
+        }
+    }
+}

--- a/GrowthBook/Plugin/Tracking/IGrowthBookPlugin.cs
+++ b/GrowthBook/Plugin/Tracking/IGrowthBookPlugin.cs
@@ -1,0 +1,39 @@
+using Newtonsoft.Json.Linq;
+
+namespace GrowthBook.Plugin
+{
+    /// <summary>
+    /// Defines a plugin that can observe GrowthBook experiment and feature evaluation events.
+    /// Implement this interface to receive lifecycle callbacks from a <see cref="GrowthBook"/> instance.
+    /// </summary>
+    public interface IGrowthBookPlugin
+    {
+        /// <summary>
+        /// Called once when the GrowthBook instance is constructed.
+        /// Use this to perform any one-time setup required by the plugin.
+        /// </summary>
+        void Init();
+
+        /// <summary>
+        /// Called each time a user is assigned to an experiment variation.
+        /// </summary>
+        /// <param name="experiment">The experiment that was evaluated.</param>
+        /// <param name="result">The result of the experiment assignment.</param>
+        /// <param name="attributes">The current user attributes at the time of evaluation.</param>
+        void OnExperimentViewed(Experiment experiment, ExperimentResult result, JObject attributes);
+
+        /// <summary>
+        /// Called each time a feature flag is evaluated.
+        /// </summary>
+        /// <param name="featureKey">The key of the evaluated feature.</param>
+        /// <param name="result">The result of the feature evaluation.</param>
+        /// <param name="attributes">The current user attributes at the time of evaluation.</param>
+        void OnFeatureEvaluated(string featureKey, FeatureResult result, JObject attributes);
+
+        /// <summary>
+        /// Called when the GrowthBook instance is disposed.
+        /// Use this to flush any pending data and release resources.
+        /// </summary>
+        void Close();
+    }
+}

--- a/GrowthBook/Plugin/Tracking/PluginRegistry.cs
+++ b/GrowthBook/Plugin/Tracking/PluginRegistry.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+
+namespace GrowthBook.Plugin
+{
+    internal class PluginRegistry
+    {
+        private readonly IList<IGrowthBookPlugin> _plugins;
+        private readonly ILogger _logger;
+
+        public bool IsEmpty => _plugins.Count == 0;
+
+        internal PluginRegistry(List<IGrowthBookPlugin> plugins, ILogger logger = null)
+        {
+            _plugins = plugins ?? new List<IGrowthBookPlugin>();
+            _logger = logger;
+        }
+
+        internal void InitAll()
+        {
+            foreach (var plugin in _plugins)
+            {
+                try
+                {
+                    plugin.Init();
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex, "Plugin {Plugin} Init failed; continuing as no-op", plugin.GetType().Name);
+                }
+            }
+        }
+
+        internal void FireExperimentViewed(Experiment experiment, ExperimentResult result, JObject attributes)
+        {
+            if (_plugins.Count == 0) return;
+            foreach (var plugin in _plugins)
+            {
+                try
+                {
+                    plugin.OnExperimentViewed(experiment, result, attributes);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex, "Plugin {Plugin} OnExperimentViewed failed", plugin.GetType().Name);
+                }
+            }
+        }
+
+        internal void FireFeatureEvaluated(string featureKey, FeatureResult result, JObject attributes)
+        {
+            if (_plugins.Count == 0) return;
+            foreach (var plugin in _plugins)
+            {
+                try
+                {
+                    plugin.OnFeatureEvaluated(featureKey, result, attributes);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex, "Plugin {Plugin} OnFeatureEvaluated failed", plugin.GetType().Name);
+                }
+            }
+        }
+
+        internal void CloseAll()
+        {
+            foreach (var plugin in _plugins)
+            {
+                try
+                {
+                    plugin.Close();
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex, "Plugin {Plugin} Close failed", plugin.GetType().Name);
+                }
+            }
+        }
+    }
+}

--- a/GrowthBook/Plugin/Tracking/SdkMetadata.cs
+++ b/GrowthBook/Plugin/Tracking/SdkMetadata.cs
@@ -1,0 +1,15 @@
+using System.Reflection;
+
+namespace GrowthBook.Plugin
+{
+    internal static class SdkMetadata
+    {
+        public const string Name = "growthbook-csharp-sdk";
+        public const string Language = "csharp";
+        public static readonly string Version = typeof(SdkMetadata).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion ?? "unknown";
+
+        public static readonly string UserAgent = Name + "/" + Version;
+    }
+}

--- a/GrowthBook/Plugin/TrackingEvent.cs
+++ b/GrowthBook/Plugin/TrackingEvent.cs
@@ -1,0 +1,79 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace GrowthBook.Plugin
+{
+    /// <summary>
+    /// Represents a single analytics event sent to the GrowthBook ingestor.
+    /// Use the static factory methods <see cref="ForExperiment"/> and <see cref="ForFeature"/>
+    /// to create instances.
+    /// </summary>
+    public class TrackingEvent
+    {
+        /// <summary>Event name used when a user is assigned to an experiment variation.</summary>
+        public const string EventExperimentViewed = "Experiment Viewed";
+
+        /// <summary>Event name used when a feature flag is evaluated.</summary>
+        public const string EventFeatureEvaluated = "Feature Evaluated";
+
+        /// <summary>The name of the event (e.g. "Experiment Viewed").</summary>
+        [JsonProperty("event_name")]
+        public string EventName { get; private set; }
+
+        /// <summary>Event-specific properties such as experiment ID or feature key.</summary>
+        [JsonProperty("properties")]
+        public JObject Properties { get; private set; }
+
+        /// <summary>User attributes merged with SDK metadata (language, version).</summary>
+        [JsonProperty("attributes")]
+        public JObject Attributes { get; private set; }
+
+        private TrackingEvent() {}
+
+        /// <summary>
+        /// Creates a tracking event for an experiment assignment.
+        /// </summary>
+        /// <param name="experiment">The experiment that was evaluated.</param>
+        /// <param name="result">The result of the assignment.</param>
+        /// <param name="attributes">User attributes to include in the event.</param>
+        public static TrackingEvent ForExperiment(Experiment experiment, ExperimentResult result, JObject attributes)
+        {
+            return new TrackingEvent
+            {
+                EventName = EventExperimentViewed,
+                Properties = new JObject
+                {
+                    ["experimentId"] = experiment?.Key, ["variationId"] = result?.VariationId,
+                },
+                Attributes = MergeWithSdkAttrs(attributes)
+            };
+        }
+
+        /// <summary>
+        /// Creates a tracking event for a feature flag evaluation.
+        /// </summary>
+        /// <param name="featureKey">The key of the evaluated feature.</param>
+        /// <param name="result">The result of the feature evaluation.</param>
+        /// <param name="attributes">User attributes to include in the event.</param>
+        public static TrackingEvent ForFeature(string featureKey, FeatureResult result, JObject attributes)
+        {
+            var props = new JObject { ["feature"] = featureKey, ["value"] = result?.Value, ["source"] = result?.Source };
+
+            return new TrackingEvent
+            {
+                EventName = EventFeatureEvaluated, Properties = props, Attributes = MergeWithSdkAttrs(attributes)
+            };
+        }
+
+        private static JObject MergeWithSdkAttrs(JObject attributes)
+        {
+            var merged = new JObject { ["sdk_language"] = SdkMetadata.Language, ["sdk_version"] = SdkMetadata.Version };
+
+            if (attributes != null)
+            {
+                merged.Merge(attributes);
+            }
+            return merged;
+        }
+    }
+}

--- a/GrowthBook/Plugin/TrackingPluginConfig.cs
+++ b/GrowthBook/Plugin/TrackingPluginConfig.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Net.Http;
+
+namespace GrowthBook.Plugin
+{
+    /// <summary>
+    /// Configuration for <see cref="GrowthBookTrackingPlugin"/>.
+    /// </summary>
+    public sealed class TrackingPluginConfig
+    {
+        /// <summary>The default GrowthBook ingestor endpoint.</summary>
+        public const string DefaultIngestorHost = "https://us1.gb-ingest.com";
+
+        /// <summary>Default number of events to accumulate before flushing to the ingestor.</summary>
+        public const int DefaultBatchSize = 100;
+
+        /// <summary>Default maximum time to wait before flushing a partial batch.</summary>
+        public static readonly TimeSpan DefaultBatchTimeout = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Base URL of the GrowthBook ingestor. Defaults to <see cref="DefaultIngestorHost"/> when not set.
+        /// Trailing slashes are stripped automatically.
+        /// </summary>
+        public string IngestorHost { get; set; }
+
+        /// <summary>
+        /// The SDK client key used to authenticate with the ingestor.
+        /// Setting this to null or empty disables the plugin.
+        /// </summary>
+        public string ClientKey { get; set; }
+
+        /// <summary>
+        /// Maximum number of events in a batch before an immediate flush is triggered.
+        /// Defaults to <see cref="DefaultBatchSize"/>.
+        /// </summary>
+        public int? BatchSize { get; set; }
+
+        /// <summary>
+        /// Maximum time to wait before flushing a partial batch.
+        /// Defaults to <see cref="DefaultBatchTimeout"/>.
+        /// </summary>
+        public TimeSpan? BatchTimeout { get; set; }
+
+        /// <summary>
+        /// Optional <see cref="System.Net.Http.HttpClient"/> to use for HTTP requests.
+        /// When not provided, an internal instance is created and owned by the plugin.
+        /// </summary>
+        public HttpClient HttpClient { get; set; }
+
+        /// <summary>Returns the effective ingestor host, falling back to <see cref="DefaultIngestorHost"/>.</summary>
+        public string ResolvedIngestorHost() =>
+            string.IsNullOrEmpty(IngestorHost)
+                ? DefaultIngestorHost
+                : IngestorHost.TrimEnd('/');
+
+        /// <summary>Returns the effective batch size, falling back to <see cref="DefaultBatchSize"/>.</summary>
+        public int ResolvedBatchSize() => BatchSize == null || BatchSize <= 0 ? DefaultBatchSize : BatchSize.Value;
+
+        /// <summary>Returns the effective batch timeout, falling back to <see cref="DefaultBatchTimeout"/>.</summary>
+        public TimeSpan ResolvedBatchTimeout() => BatchTimeout == null || BatchTimeout <= TimeSpan.Zero
+            ? DefaultBatchTimeout
+            : BatchTimeout.Value;
+    }
+}
+


### PR DESCRIPTION
## Summary
Introduces `IGrowthBookPlugin` interface for observing experiment and feature evaluations. Adds built-in `GrowthBookTrackingPlugin` that batches events and POSTs them to the GrowthBook ingest endpoint.

## Usage
```csharp
var gb = new GrowthBook(new Context
  {
      ClientKey = "sdk-abc123",
      Plugins = new List<IGrowthBookPlugin>                                                                                                                                          
      {
          new GrowthBookTrackingPlugin(new TrackingPluginConfig                                                                                                                      
          {            
              ClientKey = "sdk-abc123",
          })                                                                                                                                                                         
      }
  });
```

## What changed
- Wired plugin lifecycle into `GrowthBook` via `Context.Plugins` - plugins are initialised on construction and closed on `Dispose()`
- Routed experiment events through `TryToTrack` regardless of whether `TrackingCallback` is set, so plugins receive events without a legacy callback
- Routed feature evaluation events through `EvalFeature` / `EvalFeatureAsync` after every evaluation
- Added built-in `GrowthBookTrackingPlugin` that batches _Experiment Viewed_ and _Feature Evaluated_ events and POSTs them to the ingest endpoint
- Added `PluginRegistry` (internal) that dispatches lifecycle callbacks and isolates per-plugin exceptions
- Added tests for plugin lifecycle, evaluator integration, batching, timer-based flushing, close-time flushing, and disabled/error behavior

### Wire contract

- Endpoint: POST `{ingestorHost}/track?client_key={clientKey}`
- Default host: `https://us1.gb-ingest.com`
- Body: plain `JSON` array of events
- Headers: `Content-Type: application/json, User-Agent: growthbook-csharp-sdk/{version}`
- Event types: _Experiment Viewed, Feature Evaluated_
- Batch defaults: `batchSize=100, batchTimeout=10s`
- `Close()` performs a synchronous final flush
- `null` or empty `ClientKey` disables the plugin entirely (no HTTP calls)