### PR TITLE
Condition evaluator Improvements & support standard cases 0.7.1

### DIFF
--- a/GrowthBook.Tests/CustomTests/SecurityConditionTests.cs
+++ b/GrowthBook.Tests/CustomTests/SecurityConditionTests.cs
@@ -159,9 +159,8 @@ namespace GrowthBook.Tests.CustomTests
         }
 
         [Fact]
-        public void SecurityTest_AllComparisonOperators_WithNull_ShouldReturnFalse()
+        public void SecurityTest_ExplicitNullComparisonOperators_ShouldReturnFalse()
         {
-            // Test all comparison operators with null values
             var conditions = new[]
             {
                 @"{ ""value"": { ""$gt"": 10 } }",
@@ -171,18 +170,15 @@ namespace GrowthBook.Tests.CustomTests
             };
 
             var nullAttributes = JObject.Parse(@"{ ""value"": null }");
-            var missingAttributes = JObject.Parse("{}");
 
             foreach (var conditionJson in conditions)
             {
                 var condition = JObject.Parse(conditionJson);
                 
                 var nullResult = _provider.EvalCondition(nullAttributes, condition);
-                var missingResult = _provider.EvalCondition(missingAttributes, condition);
                 
                 nullResult.Should().BeFalse($"because null value should fail condition: {conditionJson}");
-                missingResult.Should().BeFalse($"because missing value should fail condition: {conditionJson}");
             }
         }
     }
-} 
+}

--- a/GrowthBook.Tests/Json/standard-cases.json
+++ b/GrowthBook.Tests/Json/standard-cases.json
@@ -1,5 +1,5 @@
 {
-    "specVersion": "0.7.0",
+    "specVersion": "0.7.1",
     "evalCondition": [
         [
             "$not - pass",
@@ -63,24 +63,32 @@
                 "$and": [
                     {
                         "$groups": {
-                            "$elemMatch": { "$eq": "a" }
+                            "$elemMatch": {
+                                "$eq": "a"
+                            }
                         }
                     },
                     {
                         "$groups": {
-                            "$elemMatch": { "$eq": "b" }
+                            "$elemMatch": {
+                                "$eq": "b"
+                            }
                         }
                     },
                     {
                         "$or": [
                             {
                                 "$groups": {
-                                    "$elemMatch": { "$eq": "c" }
+                                    "$elemMatch": {
+                                        "$eq": "c"
+                                    }
                                 }
                             },
                             {
                                 "$groups": {
-                                    "$elemMatch": { "$eq": "e" }
+                                    "$elemMatch": {
+                                        "$eq": "e"
+                                    }
                                 }
                             }
                         ]
@@ -88,21 +96,30 @@
                     {
                         "$not": {
                             "$groups": {
-                                "$elemMatch": { "$eq": "f" }
+                                "$elemMatch": {
+                                    "$eq": "f"
+                                }
                             }
                         }
                     },
                     {
                         "$not": {
                             "$groups": {
-                                "$elemMatch": { "$eq": "g" }
+                                "$elemMatch": {
+                                    "$eq": "g"
+                                }
                             }
                         }
                     }
                 ]
             },
             {
-                "$groups": [ "a", "b", "c", "d" ]
+                "$groups": [
+                    "a",
+                    "b",
+                    "c",
+                    "d"
+                ]
             },
             true
         ],
@@ -112,24 +129,32 @@
                 "$and": [
                     {
                         "$groups": {
-                            "$elemMatch": { "$eq": "a" }
+                            "$elemMatch": {
+                                "$eq": "a"
+                            }
                         }
                     },
                     {
                         "$groups": {
-                            "$elemMatch": { "$eq": "b" }
+                            "$elemMatch": {
+                                "$eq": "b"
+                            }
                         }
                     },
                     {
                         "$or": [
                             {
                                 "$groups": {
-                                    "$elemMatch": { "$eq": "c" }
+                                    "$elemMatch": {
+                                        "$eq": "c"
+                                    }
                                 }
                             },
                             {
                                 "$groups": {
-                                    "$elemMatch": { "$eq": "e" }
+                                    "$elemMatch": {
+                                        "$eq": "e"
+                                    }
                                 }
                             }
                         ]
@@ -137,21 +162,30 @@
                     {
                         "$not": {
                             "$groups": {
-                                "$elemMatch": { "$eq": "d" }
+                                "$elemMatch": {
+                                    "$eq": "d"
+                                }
                             }
                         }
                     },
                     {
                         "$not": {
                             "$groups": {
-                                "$elemMatch": { "$eq": "g" }
+                                "$elemMatch": {
+                                    "$eq": "g"
+                                }
                             }
                         }
                     }
                 ]
             },
             {
-                "$groups": [ "a", "b", "c", "d" ]
+                "$groups": [
+                    "a",
+                    "b",
+                    "c",
+                    "d"
+                ]
             },
             false
         ],
@@ -389,7 +423,11 @@
             "$in - pass",
             {
                 "num": {
-                    "$in": [ 1, 2, 3 ]
+                    "$in": [
+                        1,
+                        2,
+                        3
+                    ]
                 }
             },
             {
@@ -401,7 +439,11 @@
             "$in - fail",
             {
                 "num": {
-                    "$in": [ 1, 2, 3 ]
+                    "$in": [
+                        1,
+                        2,
+                        3
+                    ]
                 }
             },
             {
@@ -425,11 +467,18 @@
             "$in - array pass 1",
             {
                 "tags": {
-                    "$in": [ "a", "b" ]
+                    "$in": [
+                        "a",
+                        "b"
+                    ]
                 }
             },
             {
-                "tags": [ "d", "e", "a" ]
+                "tags": [
+                    "d",
+                    "e",
+                    "a"
+                ]
             },
             true
         ],
@@ -437,11 +486,18 @@
             "$in - array pass 2",
             {
                 "tags": {
-                    "$in": [ "a", "b" ]
+                    "$in": [
+                        "a",
+                        "b"
+                    ]
                 }
             },
             {
-                "tags": [ "d", "b", "f" ]
+                "tags": [
+                    "d",
+                    "b",
+                    "f"
+                ]
             },
             true
         ],
@@ -449,11 +505,18 @@
             "$in - array pass 3",
             {
                 "tags": {
-                    "$in": [ "a", "b" ]
+                    "$in": [
+                        "a",
+                        "b"
+                    ]
                 }
             },
             {
-                "tags": [ "d", "b", "a" ]
+                "tags": [
+                    "d",
+                    "b",
+                    "a"
+                ]
             },
             true
         ],
@@ -461,11 +524,18 @@
             "$in - array fail 1",
             {
                 "tags": {
-                    "$in": [ "a", "b" ]
+                    "$in": [
+                        "a",
+                        "b"
+                    ]
                 }
             },
             {
-                "tags": [ "d", "e", "f" ]
+                "tags": [
+                    "d",
+                    "e",
+                    "f"
+                ]
             },
             false
         ],
@@ -473,7 +543,10 @@
             "$in - array fail 2",
             {
                 "tags": {
-                    "$in": [ "a", "b" ]
+                    "$in": [
+                        "a",
+                        "b"
+                    ]
                 }
             },
             {
@@ -482,10 +555,29 @@
             false
         ],
         [
+            "$in - fail (case sensitive mismatch)",
+            {
+                "country": {
+                    "$in": [
+                        "us",
+                        "uk"
+                    ]
+                }
+            },
+            {
+                "country": "US"
+            },
+            false
+        ],
+        [
             "$nin - pass",
             {
                 "num": {
-                    "$nin": [ 1, 2, 3 ]
+                    "$nin": [
+                        1,
+                        2,
+                        3
+                    ]
                 }
             },
             {
@@ -497,7 +589,11 @@
             "$nin - fail",
             {
                 "num": {
-                    "$nin": [ 1, 2, 3 ]
+                    "$nin": [
+                        1,
+                        2,
+                        3
+                    ]
                 }
             },
             {
@@ -521,11 +617,18 @@
             "$nin - array fail 1",
             {
                 "tags": {
-                    "$nin": [ "a", "b" ]
+                    "$nin": [
+                        "a",
+                        "b"
+                    ]
                 }
             },
             {
-                "tags": [ "d", "e", "a" ]
+                "tags": [
+                    "d",
+                    "e",
+                    "a"
+                ]
             },
             false
         ],
@@ -533,11 +636,18 @@
             "$nin - array fail 2",
             {
                 "tags": {
-                    "$nin": [ "a", "b" ]
+                    "$nin": [
+                        "a",
+                        "b"
+                    ]
                 }
             },
             {
-                "tags": [ "d", "b", "f" ]
+                "tags": [
+                    "d",
+                    "b",
+                    "f"
+                ]
             },
             false
         ],
@@ -545,11 +655,18 @@
             "$nin - array fail 3",
             {
                 "tags": {
-                    "$nin": [ "a", "b" ]
+                    "$nin": [
+                        "a",
+                        "b"
+                    ]
                 }
             },
             {
-                "tags": [ "d", "b", "a" ]
+                "tags": [
+                    "d",
+                    "b",
+                    "a"
+                ]
             },
             false
         ],
@@ -557,11 +674,18 @@
             "$nin - array pass 1",
             {
                 "tags": {
-                    "$nin": [ "a", "b" ]
+                    "$nin": [
+                        "a",
+                        "b"
+                    ]
                 }
             },
             {
-                "tags": [ "d", "e", "f" ]
+                "tags": [
+                    "d",
+                    "e",
+                    "f"
+                ]
             },
             true
         ],
@@ -569,13 +693,274 @@
             "$nin - array pass 2",
             {
                 "tags": {
-                    "$nin": [ "a", "b" ]
+                    "$nin": [
+                        "a",
+                        "b"
+                    ]
                 }
             },
             {
                 "tags": []
             },
             true
+        ],
+        [
+            "$nin - pass (case sensitive mismatch)",
+            {
+                "country": {
+                    "$nin": [
+                        "us",
+                        "uk"
+                    ]
+                }
+            },
+            {
+                "country": "US"
+            },
+            true
+        ],
+        [
+            "$ini - pass (case insensitive match)",
+            {
+                "country": {
+                    "$ini": [
+                        "us",
+                        "uk"
+                    ]
+                }
+            },
+            {
+                "country": "US"
+            },
+            true
+        ],
+        [
+            "$ini - pass (uppercase pattern, lowercase value)",
+            {
+                "country": {
+                    "$ini": [
+                        "US",
+                        "UK"
+                    ]
+                }
+            },
+            {
+                "country": "us"
+            },
+            true
+        ],
+        [
+            "$ini - pass (mixed case)",
+            {
+                "country": {
+                    "$ini": [
+                        "Us",
+                        "Uk"
+                    ]
+                }
+            },
+            {
+                "country": "US"
+            },
+            true
+        ],
+        [
+            "$ini - fail (no match)",
+            {
+                "country": {
+                    "$ini": [
+                        "us",
+                        "uk"
+                    ]
+                }
+            },
+            {
+                "country": "CA"
+            },
+            false
+        ],
+        [
+            "$ini - array pass 1",
+            {
+                "tags": {
+                    "$ini": [
+                        "a",
+                        "b"
+                    ]
+                }
+            },
+            {
+                "tags": [
+                    "d",
+                    "e",
+                    "A"
+                ]
+            },
+            true
+        ],
+        [
+            "$ini - array pass 2",
+            {
+                "tags": {
+                    "$ini": [
+                        "A",
+                        "B"
+                    ]
+                }
+            },
+            {
+                "tags": [
+                    "d",
+                    "b",
+                    "f"
+                ]
+            },
+            true
+        ],
+        [
+            "$ini - array fail",
+            {
+                "tags": {
+                    "$ini": [
+                        "a",
+                        "b"
+                    ]
+                }
+            },
+            {
+                "tags": [
+                    "d",
+                    "e",
+                    "f"
+                ]
+            },
+            false
+        ],
+        [
+            "$ini - not array",
+            {
+                "num": {
+                    "$ini": 1
+                }
+            },
+            {
+                "num": 1
+            },
+            false
+        ],
+        [
+            "$nini - pass (case insensitive match)",
+            {
+                "country": {
+                    "$nini": [
+                        "us",
+                        "uk"
+                    ]
+                }
+            },
+            {
+                "country": "CA"
+            },
+            true
+        ],
+        [
+            "$nini - fail (case insensitive match)",
+            {
+                "country": {
+                    "$nini": [
+                        "us",
+                        "uk"
+                    ]
+                }
+            },
+            {
+                "country": "US"
+            },
+            false
+        ],
+        [
+            "$nini - fail (uppercase pattern, lowercase value)",
+            {
+                "country": {
+                    "$nini": [
+                        "US",
+                        "UK"
+                    ]
+                }
+            },
+            {
+                "country": "us"
+            },
+            false
+        ],
+        [
+            "$nini - array pass",
+            {
+                "tags": {
+                    "$nini": [
+                        "a",
+                        "b"
+                    ]
+                }
+            },
+            {
+                "tags": [
+                    "d",
+                    "e",
+                    "f"
+                ]
+            },
+            true
+        ],
+        [
+            "$nini - array fail 1",
+            {
+                "tags": {
+                    "$nini": [
+                        "a",
+                        "b"
+                    ]
+                }
+            },
+            {
+                "tags": [
+                    "d",
+                    "e",
+                    "A"
+                ]
+            },
+            false
+        ],
+        [
+            "$nini - array fail 2",
+            {
+                "tags": {
+                    "$nini": [
+                        "A",
+                        "B"
+                    ]
+                }
+            },
+            {
+                "tags": [
+                    "d",
+                    "b",
+                    "f"
+                ]
+            },
+            false
+        ],
+        [
+            "$nini - not array",
+            {
+                "num": {
+                    "$nini": 1
+                }
+            },
+            {
+                "num": 1
+            },
+            false
         ],
         [
             "$elemMatch - pass - flat arrays",
@@ -587,7 +972,12 @@
                 }
             },
             {
-                "nums": [ 0, 5, -20, 15 ]
+                "nums": [
+                    0,
+                    5,
+                    -20,
+                    15
+                ]
             },
             true
         ],
@@ -601,7 +991,12 @@
                 }
             },
             {
-                "nums": [ 0, 5, -20, 8 ]
+                "nums": [
+                    0,
+                    5,
+                    -20,
+                    8
+                ]
             },
             false
         ],
@@ -609,7 +1004,9 @@
             "missing attribute - fail",
             {
                 "pets.dog.name": {
-                    "$in": [ "fido" ]
+                    "$in": [
+                        "fido"
+                    ]
                 }
             },
             {
@@ -629,118 +1026,6 @@
                 }
             },
             {},
-            false
-        ],
-        [
-            "null attribute with $gt - security test",
-            {
-                "userLevel": {
-                    "$gte": 5
-                }
-            },
-            {
-                "userLevel": null
-            },
-            false
-        ],
-        [
-            "missing attribute with $gte - age verification test",
-            {
-                "age": {
-                    "$gte": 18
-                }
-            },
-            {},
-            false
-        ],
-        [
-            "null attribute with $gt - credit score test",
-            {
-                "creditScore": {
-                    "$gt": 600
-                }
-            },
-            {
-                "creditScore": null
-            },
-            false
-        ],
-        [
-            "missing attribute with $gte - resource allocation test",
-            {
-                "availableMemory": {
-                    "$gte": 1024
-                }
-            },
-            {},
-            false
-        ],
-        [
-            "null attribute with $gt - data quality test",
-            {
-                "dataQuality": {
-                    "$gt": 0.8
-                }
-            },
-            {
-                "dataQuality": null
-            },
-            false
-        ],
-        [
-            "missing attribute with $lt - upper bound test",
-            {
-                "temperature": {
-                    "$lt": 100
-                }
-            },
-            {},
-            false
-        ],
-        [
-            "null attribute with $lte - lower bound test",
-            {
-                "pressure": {
-                    "$lte": 50
-                }
-            },
-            {
-                "pressure": null
-            },
-            false
-        ],
-        [
-            "mixed conditions with missing attributes",
-            {
-                "$and": [
-                    {
-                        "age": {
-                            "$gte": 18
-                        }
-                    },
-                    {
-                        "creditScore": {
-                            "$gt": 600
-                        }
-                    }
-                ]
-            },
-            {
-                "age": 25
-            },
-            false
-        ],
-        [
-            "comparison with existing valid attribute",
-            {
-                "age": {
-                    "$gte": 18,
-                    "$lt": 65
-                }
-            },
-            {
-                "age": 30
-            },
             true
         ],
         [
@@ -862,6 +1147,54 @@
             {
                 "userAgent": {
                     "$regex": "(Mobile|Tablet)"
+                }
+            },
+            {
+                "userAgent": "Chrome Desktop Browser"
+            },
+            false
+        ],
+        [
+            "$regex - fail (case sensitive mismatch)",
+            {
+                "userAgent": {
+                    "$regex": "(mobile|tablet)"
+                }
+            },
+            {
+                "userAgent": "Android Mobile Browser"
+            },
+            false
+        ],
+        [
+            "$regexi - pass (case insensitive match)",
+            {
+                "userAgent": {
+                    "$regexi": "(mobile|tablet)"
+                }
+            },
+            {
+                "userAgent": "Android Mobile Browser"
+            },
+            true
+        ],
+        [
+            "$regexi - pass (uppercase pattern, lowercase value)",
+            {
+                "userAgent": {
+                    "$regexi": "(MOBILE|TABLET)"
+                }
+            },
+            {
+                "userAgent": "android mobile browser"
+            },
+            true
+        ],
+        [
+            "$regexi - fail",
+            {
+                "userAgent": {
+                    "$regexi": "(mobile|tablet)"
                 }
             },
             {
@@ -1175,7 +1508,10 @@
                 }
             },
             {
-                "a": [ 1, 2 ]
+                "a": [
+                    1,
+                    2
+                ]
             },
             true
         ],
@@ -1230,7 +1566,9 @@
         [
             "$size empty - pass",
             {
-                "tags": { "$size": 0 }
+                "tags": {
+                    "$size": 0
+                }
             },
             {
                 "tags": []
@@ -1240,10 +1578,14 @@
         [
             "$size empty - fail",
             {
-                "tags": { "$size": 0 }
+                "tags": {
+                    "$size": 0
+                }
             },
             {
-                "tags": [ 10 ]
+                "tags": [
+                    10
+                ]
             },
             false
         ],
@@ -1255,7 +1597,11 @@
                 }
             },
             {
-                "tags": [ "a", "b", "c" ]
+                "tags": [
+                    "a",
+                    "b",
+                    "c"
+                ]
             },
             true
         ],
@@ -1267,7 +1613,10 @@
                 }
             },
             {
-                "tags": [ "a", "b" ]
+                "tags": [
+                    "a",
+                    "b"
+                ]
             },
             false
         ],
@@ -1279,7 +1628,12 @@
                 }
             },
             {
-                "tags": [ "a", "b", "c", "d" ]
+                "tags": [
+                    "a",
+                    "b",
+                    "c",
+                    "d"
+                ]
             },
             false
         ],
@@ -1305,7 +1659,11 @@
                 }
             },
             {
-                "tags": [ 0, 1, 2 ]
+                "tags": [
+                    0,
+                    1,
+                    2
+                ]
             },
             true
         ],
@@ -1319,7 +1677,10 @@
                 }
             },
             {
-                "tags": [ 0, 1 ]
+                "tags": [
+                    0,
+                    1
+                ]
             },
             false
         ],
@@ -1333,7 +1694,9 @@
                 }
             },
             {
-                "tags": [ 0 ]
+                "tags": [
+                    0
+                ]
             },
             false
         ],
@@ -1347,7 +1710,11 @@
                 }
             },
             {
-                "tags": [ "foo", "bar", "baz" ]
+                "tags": [
+                    "foo",
+                    "bar",
+                    "baz"
+                ]
             },
             true
         ],
@@ -1361,7 +1728,10 @@
                 }
             },
             {
-                "tags": [ "foo", "baz" ]
+                "tags": [
+                    "foo",
+                    "baz"
+                ]
             },
             false
         ],
@@ -1370,12 +1740,19 @@
             {
                 "tags": {
                     "$elemMatch": {
-                        "$in": [ "a", "b" ]
+                        "$in": [
+                            "a",
+                            "b"
+                        ]
                     }
                 }
             },
             {
-                "tags": [ "d", "e", "b" ]
+                "tags": [
+                    "d",
+                    "e",
+                    "b"
+                ]
             },
             true
         ],
@@ -1384,12 +1761,19 @@
             {
                 "tags": {
                     "$elemMatch": {
-                        "$in": [ "a", "b" ]
+                        "$in": [
+                            "a",
+                            "b"
+                        ]
                     }
                 }
             },
             {
-                "tags": [ "d", "e", "f" ]
+                "tags": [
+                    "d",
+                    "e",
+                    "f"
+                ]
             },
             false
         ],
@@ -1405,7 +1789,10 @@
                 }
             },
             {
-                "tags": [ "foo", "baz" ]
+                "tags": [
+                    "foo",
+                    "baz"
+                ]
             },
             true
         ],
@@ -1421,7 +1808,11 @@
                 }
             },
             {
-                "tags": [ "foo", "bar", "baz" ]
+                "tags": [
+                    "foo",
+                    "bar",
+                    "baz"
+                ]
             },
             false
         ],
@@ -1522,11 +1913,18 @@
             "$all - pass",
             {
                 "tags": {
-                    "$all": [ "one", "three" ]
+                    "$all": [
+                        "one",
+                        "three"
+                    ]
                 }
             },
             {
-                "tags": [ "one", "two", "three" ]
+                "tags": [
+                    "one",
+                    "two",
+                    "three"
+                ]
             },
             true
         ],
@@ -1534,11 +1932,18 @@
             "$all - fail",
             {
                 "tags": {
-                    "$all": [ "one", "three" ]
+                    "$all": [
+                        "one",
+                        "three"
+                    ]
                 }
             },
             {
-                "tags": [ "one", "two", "four" ]
+                "tags": [
+                    "one",
+                    "two",
+                    "four"
+                ]
             },
             false
         ],
@@ -1546,7 +1951,120 @@
             "$all - fail not array",
             {
                 "tags": {
-                    "$all": [ "one", "three" ]
+                    "$all": [
+                        "one",
+                        "three"
+                    ]
+                }
+            },
+            {
+                "tags": "hello"
+            },
+            false
+        ],
+        [
+            "$all - fail (case sensitive mismatch)",
+            {
+                "tags": {
+                    "$all": [
+                        "one",
+                        "three"
+                    ]
+                }
+            },
+            {
+                "tags": [
+                    "ONE",
+                    "two",
+                    "THREE"
+                ]
+            },
+            false
+        ],
+        [
+            "$alli - pass (case insensitive match)",
+            {
+                "tags": {
+                    "$alli": [
+                        "one",
+                        "three"
+                    ]
+                }
+            },
+            {
+                "tags": [
+                    "ONE",
+                    "two",
+                    "THREE"
+                ]
+            },
+            true
+        ],
+        [
+            "$alli - pass (uppercase pattern, lowercase value)",
+            {
+                "tags": {
+                    "$alli": [
+                        "ONE",
+                        "THREE"
+                    ]
+                }
+            },
+            {
+                "tags": [
+                    "one",
+                    "two",
+                    "three"
+                ]
+            },
+            true
+        ],
+        [
+            "$alli - pass (mixed case)",
+            {
+                "tags": {
+                    "$alli": [
+                        "One",
+                        "Three"
+                    ]
+                }
+            },
+            {
+                "tags": [
+                    "ONE",
+                    "two",
+                    "three"
+                ]
+            },
+            true
+        ],
+        [
+            "$alli - fail (case insensitive, missing value)",
+            {
+                "tags": {
+                    "$alli": [
+                        "one",
+                        "three"
+                    ]
+                }
+            },
+            {
+                "tags": [
+                    "ONE",
+                    "two",
+                    "four"
+                ]
+            },
+            false
+        ],
+        [
+            "$alli - fail not array",
+            {
+                "tags": {
+                    "$alli": [
+                        "one",
+                        "three"
+                    ]
                 }
             },
             {
@@ -1637,47 +2155,74 @@
         [
             "equals array - pass",
             {
-                "tags": [ "hello", "world" ]
+                "tags": [
+                    "hello",
+                    "world"
+                ]
             },
             {
-                "tags": [ "hello", "world" ]
+                "tags": [
+                    "hello",
+                    "world"
+                ]
             },
             true
         ],
         [
             "equals array - fail order",
             {
-                "tags": [ "hello", "world" ]
+                "tags": [
+                    "hello",
+                    "world"
+                ]
             },
             {
-                "tags": [ "world", "hello" ]
+                "tags": [
+                    "world",
+                    "hello"
+                ]
             },
             false
         ],
         [
             "equals array - fail missing item",
             {
-                "tags": [ "hello", "world" ]
+                "tags": [
+                    "hello",
+                    "world"
+                ]
             },
             {
-                "tags": [ "hello" ]
+                "tags": [
+                    "hello"
+                ]
             },
             false
         ],
         [
             "equals array - fail extra item",
             {
-                "tags": [ "hello", "world" ]
+                "tags": [
+                    "hello",
+                    "world"
+                ]
             },
             {
-                "tags": [ "hello", "world", "foo" ]
+                "tags": [
+                    "hello",
+                    "world",
+                    "foo"
+                ]
             },
             false
         ],
         [
             "equals array - fail type mismatch",
             {
-                "tags": [ "hello", "world" ]
+                "tags": [
+                    "hello",
+                    "world"
+                ]
             },
             {
                 "tags": "hello world"
@@ -1783,6 +2328,34 @@
             {
                 "userId": ""
             },
+            false
+        ],
+        [
+            "null condition - false attribute",
+            {
+                "userId": null
+            },
+            {
+                "userId": false
+            },
+            false
+        ],
+        [
+            "false condition - missing attribute",
+            {
+                "userId": false
+            },
+            {},
+            false
+        ],
+        [
+            "false strict condition - missing attribute",
+            {
+                "userId": {
+                    "$eq": false
+                }
+            },
+            {},
             false
         ],
         [
@@ -2892,8 +3465,12 @@
             "$or pass but second condition fail",
             {
                 "$or": [
-                    { "foo": 1 },
-                    { "bar": 1 }
+                    {
+                        "foo": 1
+                    },
+                    {
+                        "bar": 1
+                    }
                 ],
                 "baz": 2
             },
@@ -2908,8 +3485,12 @@
             "$or and second condition both pass",
             {
                 "$or": [
-                    { "foo": 1 },
-                    { "bar": 1 }
+                    {
+                        "foo": 1
+                    },
+                    {
+                        "bar": 1
+                    }
                 ],
                 "baz": 2
             },
@@ -2924,12 +3505,20 @@
             "$and condition pass but $or fail",
             {
                 "$and": [
-                    { "foo": 1 },
-                    { "bar": 1 }
+                    {
+                        "foo": 1
+                    },
+                    {
+                        "bar": 1
+                    }
                 ],
                 "$or": [
-                    { "baz": 1 },
-                    { "empty": 1 }
+                    {
+                        "baz": 1
+                    },
+                    {
+                        "empty": 1
+                    }
                 ]
             },
             {
@@ -2943,12 +3532,20 @@
             "$and and $or both pass",
             {
                 "$and": [
-                    { "foo": 1 },
-                    { "bar": 1 }
+                    {
+                        "foo": 1
+                    },
+                    {
+                        "bar": 1
+                    }
                 ],
                 "$or": [
-                    { "baz": 1 },
-                    { "empty": 1 }
+                    {
+                        "baz": 1
+                    },
+                    {
+                        "empty": 1
+                    }
                 ]
             },
             {
@@ -2962,126 +3559,439 @@
         [
             "$inGroup passes for member of known group id",
             {
-                "id": { "$inGroup": "group_id" }
+                "id": {
+                    "$inGroup": "group_id"
+                }
             },
-            { "id": 1 },
+            {
+                "id": 1
+            },
             true,
-            { "group_id": [ 1, 2, 3 ] }
+            {
+                "group_id": [
+                    1,
+                    2,
+                    3
+                ]
+            }
         ],
         [
             "$inGroup fails for non-member of known group id",
             {
-                "id": { "$inGroup": "group_id" }
+                "id": {
+                    "$inGroup": "group_id"
+                }
             },
-            { "id": 5 },
+            {
+                "id": 5
+            },
             false,
-            { "group_id": [ 1, 2, 3 ] }
+            {
+                "group_id": [
+                    1,
+                    2,
+                    3
+                ]
+            }
         ],
         [
             "$inGroup fails for unknown group id",
             {
-                "id": { "$inGroup": "unknowngroup_id" }
+                "id": {
+                    "$inGroup": "unknowngroup_id"
+                }
             },
-            { "id": 1 },
+            {
+                "id": 1
+            },
             false,
-            { "group_id": [ 1, 2, 3 ] }
+            {
+                "group_id": [
+                    1,
+                    2,
+                    3
+                ]
+            }
         ],
         [
             "$notInGroup fails for member of known group id",
             {
-                "id": { "$notInGroup": "group_id" }
+                "id": {
+                    "$notInGroup": "group_id"
+                }
             },
-            { "id": 1 },
+            {
+                "id": 1
+            },
             false,
-            { "group_id": [ 1, 2, 3 ] }
+            {
+                "group_id": [
+                    1,
+                    2,
+                    3
+                ]
+            }
         ],
         [
             "$notInGroup passes for non-member of known group id",
             {
-                "id": { "$notInGroup": "group_id" }
+                "id": {
+                    "$notInGroup": "group_id"
+                }
             },
-            { "id": 5 },
+            {
+                "id": 5
+            },
             true,
-            { "group_id": [ 1, 2, 3 ] }
+            {
+                "group_id": [
+                    1,
+                    2,
+                    3
+                ]
+            }
         ],
         [
             "$notInGroup passes for unknown group id",
             {
-                "id": { "$notInGroup": "unknowngroup_id" }
+                "id": {
+                    "$notInGroup": "unknowngroup_id"
+                }
             },
-            { "id": 1 },
+            {
+                "id": 1
+            },
             true,
-            { "group_id": [ 1, 2, 3 ] }
+            {
+                "group_id": [
+                    1,
+                    2,
+                    3
+                ]
+            }
         ],
         [
             "$inGroup passes for properly typed data",
             {
-                "id": { "$inGroup": "group_id" }
+                "id": {
+                    "$inGroup": "group_id"
+                }
             },
-            { "id": "2" },
+            {
+                "id": "2"
+            },
             true,
-            { "group_id": [ 1, "2", 3 ] }
+            {
+                "group_id": [
+                    1,
+                    "2",
+                    3
+                ]
+            }
         ],
         [
             "$inGroup fails for improperly typed data",
             {
-                "id": { "$inGroup": "group_id" }
+                "id": {
+                    "$inGroup": "group_id"
+                }
             },
-            { "id": "3" },
+            {
+                "id": "3"
+            },
             false,
-            { "group_id": [ 1, "2", 3 ] }
+            {
+                "group_id": [
+                    1,
+                    "2",
+                    3
+                ]
+            }
+        ],
+        [
+            "null attribute with $gt - security test",
+            {
+                "userLevel": {
+                    "$gte": 5
+                }
+            },
+            {
+                "userLevel": null
+            },
+            false
+        ],
+        [
+            "missing attribute with $gte - age verification test",
+            {
+                "age": {
+                    "$gte": 18
+                }
+            },
+            {},
+            false
+        ],
+        [
+            "null attribute with $gt - credit score test",
+            {
+                "creditScore": {
+                    "$gt": 600
+                }
+            },
+            {
+                "creditScore": null
+            },
+            false
+        ],
+        [
+            "missing attribute with $gte - resource allocation test",
+            {
+                "availableMemory": {
+                    "$gte": 1024
+                }
+            },
+            {},
+            false
+        ],
+        [
+            "null attribute with $gt - data quality test",
+            {
+                "dataQuality": {
+                    "$gt": 0.8
+                }
+            },
+            {
+                "dataQuality": null
+            },
+            false
+        ],
+        [
+            "missing attribute with $lt - negative upper bound test",
+            {
+                "temperature": {
+                    "$lt": -100
+                }
+            },
+            {},
+            false
+        ],
+        [
+            "null attribute with $lte - lower bound test",
+            {
+                "pressure": {
+                    "$lte": 50
+                }
+            },
+            {
+                "pressure": null
+            },
+            false
+        ],
+        [
+            "mixed conditions with missing attributes",
+            {
+                "$and": [
+                    {
+                        "age": {
+                            "$gte": 18
+                        }
+                    },
+                    {
+                        "creditScore": {
+                            "$gt": 600
+                        }
+                    }
+                ]
+            },
+            {
+                "age": 25
+            },
+            false
+        ],
+        [
+            "comparison with existing valid attribute",
+            {
+                "age": {
+                    "$gte": 18,
+                    "$lt": 65
+                }
+            },
+            {
+                "age": 30
+            },
+            true
         ]
     ],
     "hash": [
-        [ "", "a", 1, 0.22 ],
-        [ "", "b", 1, 0.077 ],
-        [ "b", "a", 1, 0.946 ],
-        [ "ef", "d", 1, 0.652 ],
-        [ "asdf", "8952klfjas09ujk", 1, 0.549 ],
-        [ "", "123", 1, 0.011 ],
-        [ "", "___)((*\":&", 1, 0.563 ],
-        [ "seed", "a", 2, 0.0505 ],
-        [ "seed", "b", 2, 0.2696 ],
-        [ "foo", "ab", 2, 0.2575 ],
-        [ "foo", "def", 2, 0.2019 ],
-        [ "89123klj", "8952klfjas09ujkasdf", 2, 0.124 ],
-        [ "90850943850283058242805", "123", 2, 0.7516 ],
-        [ "()**(%$##$%#$#", "___)((*\":&", 2, 0.0128 ],
-        [ "abc", "def", 99, null ]
+        [
+            "",
+            "a",
+            1,
+            0.22
+        ],
+        [
+            "",
+            "b",
+            1,
+            0.077
+        ],
+        [
+            "b",
+            "a",
+            1,
+            0.946
+        ],
+        [
+            "ef",
+            "d",
+            1,
+            0.652
+        ],
+        [
+            "asdf",
+            "8952klfjas09ujk",
+            1,
+            0.549
+        ],
+        [
+            "",
+            "123",
+            1,
+            0.011
+        ],
+        [
+            "",
+            "___)((*\":&",
+            1,
+            0.563
+        ],
+        [
+            "seed",
+            "a",
+            2,
+            0.0505
+        ],
+        [
+            "seed",
+            "b",
+            2,
+            0.2696
+        ],
+        [
+            "foo",
+            "ab",
+            2,
+            0.2575
+        ],
+        [
+            "foo",
+            "def",
+            2,
+            0.2019
+        ],
+        [
+            "89123klj",
+            "8952klfjas09ujkasdf",
+            2,
+            0.124
+        ],
+        [
+            "90850943850283058242805",
+            "123",
+            2,
+            0.7516
+        ],
+        [
+            "()**(%$##$%#$#",
+            "___)((*\":&",
+            2,
+            0.0128
+        ],
+        [
+            "abc",
+            "def",
+            99,
+            null
+        ]
     ],
     "getBucketRange": [
         [
             "normal 50/50",
-            [ 2, 1, null ],
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                2,
+                1,
+                null
+            ],
+            [
+                [
+                    0,
+                    0.5
+                ],
+                [
+                    0.5,
+                    1
+                ]
             ]
         ],
         [
             "reduced coverage",
-            [ 2, 0.5, null ],
             [
-                [ 0, 0.25 ],
-                [ 0.5, 0.75 ]
+                2,
+                0.5,
+                null
+            ],
+            [
+                [
+                    0,
+                    0.25
+                ],
+                [
+                    0.5,
+                    0.75
+                ]
             ]
         ],
         [
             "zero coverage",
-            [ 2, 0, null ],
             [
-                [ 0, 0 ],
-                [ 0.5, 0.5 ]
+                2,
+                0,
+                null
+            ],
+            [
+                [
+                    0,
+                    0
+                ],
+                [
+                    0.5,
+                    0.5
+                ]
             ]
         ],
         [
             "4 variations",
-            [ 4, 1, null ],
             [
-                [ 0, 0.25 ],
-                [ 0.25, 0.5 ],
-                [ 0.5, 0.75 ],
-                [ 0.75, 1 ]
+                4,
+                1,
+                null
+            ],
+            [
+                [
+                    0,
+                    0.25
+                ],
+                [
+                    0.25,
+                    0.5
+                ],
+                [
+                    0.5,
+                    0.75
+                ],
+                [
+                    0.75,
+                    1
+                ]
             ]
         ],
         [
@@ -3089,11 +3999,20 @@
             [
                 2,
                 1,
-                [ 0.4, 0.6 ]
+                [
+                    0.4,
+                    0.6
+                ]
             ],
             [
-                [ 0, 0.4 ],
-                [ 0.4, 1 ]
+                [
+                    0,
+                    0.4
+                ],
+                [
+                    0.4,
+                    1
+                ]
             ]
         ],
         [
@@ -3101,12 +4020,25 @@
             [
                 3,
                 1,
-                [ 0.2, 0.3, 0.5 ]
+                [
+                    0.2,
+                    0.3,
+                    0.5
+                ]
             ],
             [
-                [ 0, 0.2 ],
-                [ 0.2, 0.5 ],
-                [ 0.5, 1 ]
+                [
+                    0,
+                    0.2
+                ],
+                [
+                    0.2,
+                    0.5
+                ],
+                [
+                    0.5,
+                    1
+                ]
             ]
         ],
         [
@@ -3114,28 +4046,61 @@
             [
                 3,
                 0.2,
-                [ 0.2, 0.3, 0.5 ]
+                [
+                    0.2,
+                    0.3,
+                    0.5
+                ]
             ],
             [
-                [ 0, 0.04 ],
-                [ 0.2, 0.26 ],
-                [ 0.5, 0.6 ]
+                [
+                    0,
+                    0.04
+                ],
+                [
+                    0.2,
+                    0.26
+                ],
+                [
+                    0.5,
+                    0.6
+                ]
             ]
         ],
         [
             "negative coverage",
-            [ 2, -0.2, null ],
             [
-                [ 0, 0 ],
-                [ 0.5, 0.5 ]
+                2,
+                -0.2,
+                null
+            ],
+            [
+                [
+                    0,
+                    0
+                ],
+                [
+                    0.5,
+                    0.5
+                ]
             ]
         ],
         [
             "coverage above 1",
-            [ 2, 1.5, null ],
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                2,
+                1.5,
+                null
+            ],
+            [
+                [
+                    0,
+                    0.5
+                ],
+                [
+                    0.5,
+                    1
+                ]
             ]
         ],
         [
@@ -3143,11 +4108,20 @@
             [
                 2,
                 1,
-                [ 0.4, 0.1 ]
+                [
+                    0.4,
+                    0.1
+                ]
             ],
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [
+                    0,
+                    0.5
+                ],
+                [
+                    0.5,
+                    1
+                ]
             ]
         ],
         [
@@ -3155,11 +4129,20 @@
             [
                 2,
                 1,
-                [ 0.7, 0.6 ]
+                [
+                    0.7,
+                    0.6
+                ]
             ],
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [
+                    0,
+                    0.5
+                ],
+                [
+                    0.5,
+                    1
+                ]
             ]
         ],
         [
@@ -3167,13 +4150,29 @@
             [
                 4,
                 1,
-                [ 0.4, 0.4, 0.2 ]
+                [
+                    0.4,
+                    0.4,
+                    0.2
+                ]
             ],
             [
-                [ 0, 0.25 ],
-                [ 0.25, 0.5 ],
-                [ 0.5, 0.75 ],
-                [ 0.75, 1 ]
+                [
+                    0,
+                    0.25
+                ],
+                [
+                    0.25,
+                    0.5
+                ],
+                [
+                    0.5,
+                    0.75
+                ],
+                [
+                    0.75,
+                    1
+                ]
             ]
         ],
         [
@@ -3181,11 +4180,20 @@
             [
                 2,
                 1,
-                [ 0.4, 0.5999 ]
+                [
+                    0.4,
+                    0.5999
+                ]
             ],
             [
-                [ 0, 0.4 ],
-                [ 0.4, 0.9999 ]
+                [
+                    0,
+                    0.4
+                ],
+                [
+                    0.4,
+                    0.9999
+                ]
             ]
         ]
     ],
@@ -3198,40 +4206,60 @@
                 "value": null,
                 "on": false,
                 "off": true,
-                "source": "unknownFeature"
+                "source": "unknownFeature",
+                "ruleId": ""
             }
         ],
         [
             "defaults when empty",
-            { "features": { "feature": {} } },
+            {
+                "features": {
+                    "feature": {}
+                }
+            },
             "feature",
             {
                 "value": null,
                 "on": false,
                 "off": true,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
             "uses defaultValue - number",
-            { "features": { "feature": { "defaultValue": 1 } } },
+            {
+                "features": {
+                    "feature": {
+                        "defaultValue": 1
+                    }
+                }
+            },
             "feature",
             {
                 "value": 1,
                 "on": true,
                 "off": false,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
             "uses custom values - string",
-            { "features": { "feature": { "defaultValue": "yes" } } },
+            {
+                "features": {
+                    "feature": {
+                        "defaultValue": "yes"
+                    }
+                }
+            },
             "feature",
             {
                 "value": "yes",
                 "on": true,
                 "off": false,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -3253,7 +4281,32 @@
                 "value": 1,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
+            }
+        ],
+        [
+            "force rule with rule id",
+            {
+                "features": {
+                    "feature": {
+                        "defaultValue": 2,
+                        "rules": [
+                            {
+                                "id": "a",
+                                "force": 1
+                            }
+                        ]
+                    }
+                }
+            },
+            "feature",
+            {
+                "value": 1,
+                "on": true,
+                "off": false,
+                "source": "force",
+                "ruleId": "a"
             }
         ],
         [
@@ -3275,7 +4328,8 @@
                 "value": false,
                 "on": false,
                 "off": true,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -3301,7 +4355,8 @@
                 "value": 1,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -3327,7 +4382,8 @@
                 "value": 1,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -3341,6 +4397,7 @@
                         "defaultValue": 2,
                         "rules": [
                             {
+                                "id": "a",
                                 "force": 1,
                                 "coverage": 0.5
                             }
@@ -3353,7 +4410,8 @@
                 "value": 2,
                 "on": true,
                 "off": false,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -3377,7 +4435,8 @@
                 "value": 2,
                 "on": true,
                 "off": false,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -3404,7 +4463,8 @@
                 "value": 0,
                 "on": false,
                 "off": true,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -3421,7 +4481,12 @@
                             {
                                 "force": 1,
                                 "condition": {
-                                    "country": { "$in": [ "US", "CA" ] },
+                                    "country": {
+                                        "$in": [
+                                            "US",
+                                            "CA"
+                                        ]
+                                    },
                                     "browser": "firefox"
                                 }
                             }
@@ -3434,7 +4499,8 @@
                 "value": 1,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -3451,7 +4517,12 @@
                             {
                                 "force": 1,
                                 "condition": {
-                                    "country": { "$in": [ "US", "CA" ] },
+                                    "country": {
+                                        "$in": [
+                                            "US",
+                                            "CA"
+                                        ]
+                                    },
                                     "browser": "firefox"
                                 }
                             }
@@ -3464,7 +4535,8 @@
                 "value": 2,
                 "on": true,
                 "off": false,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -3479,7 +4551,7 @@
                         "rules": [
                             {
                                 "force": 1,
-                                "coverage": 1.0,
+                                "coverage": 1,
                                 "hashVersion": 99
                             }
                         ]
@@ -3491,7 +4563,8 @@
                 "value": 2,
                 "on": true,
                 "off": false,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -3499,7 +4572,9 @@
             {
                 "features": {
                     "feature": {
-                        "rules": [ {} ]
+                        "rules": [
+                            {}
+                        ]
                     }
                 }
             },
@@ -3508,7 +4583,8 @@
                 "value": null,
                 "on": false,
                 "off": true,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -3521,7 +4597,11 @@
                     "feature": {
                         "rules": [
                             {
-                                "variations": [ "a", "b", "c" ]
+                                "variations": [
+                                    "a",
+                                    "b",
+                                    "c"
+                                ]
                             }
                         ]
                     }
@@ -3534,7 +4614,11 @@
                 "off": false,
                 "experiment": {
                     "key": "feature",
-                    "variations": [ "a", "b", "c" ]
+                    "variations": [
+                        "a",
+                        "b",
+                        "c"
+                    ]
                 },
                 "experimentResult": {
                     "featureId": "feature",
@@ -3548,7 +4632,8 @@
                     "key": "2",
                     "stickyBucketUsed": false
                 },
-                "source": "experiment"
+                "source": "experiment",
+                "ruleId": ""
             }
         ],
         [
@@ -3561,7 +4646,12 @@
                     "feature": {
                         "rules": [
                             {
-                                "variations": [ "a", "b", "c" ]
+                                "id": "id",
+                                "variations": [
+                                    "a",
+                                    "b",
+                                    "c"
+                                ]
                             }
                         ]
                     }
@@ -3574,7 +4664,11 @@
                 "off": false,
                 "experiment": {
                     "key": "feature",
-                    "variations": [ "a", "b", "c" ]
+                    "variations": [
+                        "a",
+                        "b",
+                        "c"
+                    ]
                 },
                 "experimentResult": {
                     "featureId": "feature",
@@ -3588,7 +4682,8 @@
                     "key": "0",
                     "stickyBucketUsed": false
                 },
-                "source": "experiment"
+                "source": "experiment",
+                "ruleId": "id"
             }
         ],
         [
@@ -3601,7 +4696,11 @@
                     "feature": {
                         "rules": [
                             {
-                                "variations": [ "a", "b", "c" ]
+                                "variations": [
+                                    "a",
+                                    "b",
+                                    "c"
+                                ]
                             }
                         ]
                     }
@@ -3614,7 +4713,11 @@
                 "off": false,
                 "experiment": {
                     "key": "feature",
-                    "variations": [ "a", "b", "c" ]
+                    "variations": [
+                        "a",
+                        "b",
+                        "c"
+                    ]
                 },
                 "experimentResult": {
                     "featureId": "feature",
@@ -3628,7 +4731,8 @@
                     "key": "1",
                     "stickyBucketUsed": false
                 },
-                "source": "experiment"
+                "source": "experiment",
+                "ruleId": ""
             }
         ],
         [
@@ -3649,8 +4753,14 @@
                                 "name": "Test",
                                 "phase": "1",
                                 "ranges": [
-                                    [ 0, 0.1 ],
-                                    [ 0.1, 1.0 ]
+                                    [
+                                        0,
+                                        0.1
+                                    ],
+                                    [
+                                        0.1,
+                                        1
+                                    ]
                                 ],
                                 "meta": [
                                     {
@@ -3666,14 +4776,32 @@
                                     {
                                         "attribute": "anonId",
                                         "seed": "pricing",
-                                        "ranges": [ [ 0, 1 ] ]
+                                        "ranges": [
+                                            [
+                                                0,
+                                                1
+                                            ]
+                                        ]
                                     }
                                 ],
-                                "namespace": [ "pricing", 0, 1 ],
+                                "namespace": [
+                                    "pricing",
+                                    0,
+                                    1
+                                ],
                                 "key": "hello",
-                                "variations": [ true, false ],
-                                "weights": [ 0.1, 0.9 ],
-                                "condition": { "premium": true }
+                                "variations": [
+                                    true,
+                                    false
+                                ],
+                                "weights": [
+                                    0.1,
+                                    0.9
+                                ],
+                                "condition": {
+                                    "premium": true
+                                },
+                                "foo": "bar"
                             }
                         ]
                     }
@@ -3688,8 +4816,14 @@
                 "experiment": {
                     "coverage": 0.99,
                     "ranges": [
-                        [ 0, 0.1 ],
-                        [ 0.1, 1.0 ]
+                        [
+                            0,
+                            0.1
+                        ],
+                        [
+                            0.1,
+                            1
+                        ]
                     ],
                     "meta": [
                         {
@@ -3705,7 +4839,12 @@
                         {
                             "attribute": "anonId",
                             "seed": "pricing",
-                            "ranges": [ [ 0, 1 ] ]
+                            "ranges": [
+                                [
+                                    0,
+                                    1
+                                ]
+                            ]
                         }
                     ],
                     "name": "Test",
@@ -3713,11 +4852,23 @@
                     "seed": "feature",
                     "hashVersion": 2,
                     "hashAttribute": "anonId",
-                    "namespace": [ "pricing", 0, 1 ],
+                    "namespace": [
+                        "pricing",
+                        0,
+                        1
+                    ],
                     "key": "hello",
-                    "variations": [ true, false ],
-                    "weights": [ 0.1, 0.9 ],
-                    "condition": { "premium": true }
+                    "variations": [
+                        true,
+                        false
+                    ],
+                    "weights": [
+                        0.1,
+                        0.9
+                    ],
+                    "condition": {
+                        "premium": true
+                    }
                 },
                 "experimentResult": {
                     "featureId": "feature",
@@ -3731,7 +4882,8 @@
                     "key": "v1",
                     "name": "variation 1",
                     "stickyBucketUsed": false
-                }
+                },
+                "ruleId": ""
             }
         ],
         [
@@ -3746,15 +4898,21 @@
                         "rules": [
                             {
                                 "force": 1,
-                                "condition": { "browser": "chrome" }
+                                "condition": {
+                                    "browser": "chrome"
+                                }
                             },
                             {
                                 "force": 2,
-                                "condition": { "browser": "firefox" }
+                                "condition": {
+                                    "browser": "firefox"
+                                }
                             },
                             {
                                 "force": 3,
-                                "condition": { "browser": "safari" }
+                                "condition": {
+                                    "browser": "safari"
+                                }
                             }
                         ]
                     }
@@ -3765,7 +4923,8 @@
                 "value": 2,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -3780,15 +4939,24 @@
                         "rules": [
                             {
                                 "force": 1,
-                                "condition": { "browser": "chrome" }
+                                "id": "1",
+                                "condition": {
+                                    "browser": "chrome"
+                                }
                             },
                             {
+                                "id": "2",
                                 "force": 2,
-                                "condition": { "browser": "firefox" }
+                                "condition": {
+                                    "browser": "firefox"
+                                }
                             },
                             {
+                                "id": "3",
                                 "force": 3,
-                                "condition": { "browser": "safari" }
+                                "condition": {
+                                    "browser": "safari"
+                                }
                             }
                         ]
                     }
@@ -3799,7 +4967,8 @@
                 "value": 3,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": "3"
             }
         ],
         [
@@ -3814,15 +4983,21 @@
                         "rules": [
                             {
                                 "force": 1,
-                                "condition": { "browser": "chrome" }
+                                "condition": {
+                                    "browser": "chrome"
+                                }
                             },
                             {
                                 "force": 2,
-                                "condition": { "browser": "firefox" }
+                                "condition": {
+                                    "browser": "firefox"
+                                }
                             },
                             {
                                 "force": 3,
-                                "condition": { "browser": "safari" }
+                                "condition": {
+                                    "browser": "safari"
+                                }
                             }
                         ]
                     }
@@ -3833,19 +5008,27 @@
                 "value": 0,
                 "on": false,
                 "off": true,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
             "skips experiment on coverage",
             {
-                "attributes": { "id": "123" },
+                "attributes": {
+                    "id": "123"
+                },
                 "features": {
                     "feature": {
                         "defaultValue": 0,
                         "rules": [
                             {
-                                "variations": [ 0, 1, 2, 3 ],
+                                "variations": [
+                                    0,
+                                    1,
+                                    2,
+                                    3
+                                ],
                                 "coverage": 0.01
                             },
                             {
@@ -3860,20 +5043,32 @@
                 "value": 3,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
             "skips experiment on namespace",
             {
-                "attributes": { "id": "123" },
+                "attributes": {
+                    "id": "123"
+                },
                 "features": {
                     "feature": {
                         "defaultValue": 0,
                         "rules": [
                             {
-                                "variations": [ 0, 1, 2, 3 ],
-                                "namespace": [ "pricing", 0, 0.01 ]
+                                "variations": [
+                                    0,
+                                    1,
+                                    2,
+                                    3
+                                ],
+                                "namespace": [
+                                    "pricing",
+                                    0,
+                                    0.01
+                                ]
                             },
                             {
                                 "force": 3
@@ -3887,19 +5082,25 @@
                 "value": 3,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
             "handles integer hashAttribute",
             {
-                "attributes": { "id": 123 },
+                "attributes": {
+                    "id": 123
+                },
                 "features": {
                     "feature": {
                         "defaultValue": 0,
                         "rules": [
                             {
-                                "variations": [ 0, 1 ]
+                                "variations": [
+                                    0,
+                                    1
+                                ]
                             }
                         ]
                     }
@@ -3913,7 +5114,10 @@
                 "source": "experiment",
                 "experiment": {
                     "key": "feature",
-                    "variations": [ 0, 1 ]
+                    "variations": [
+                        0,
+                        1
+                    ]
                 },
                 "experimentResult": {
                     "featureId": "feature",
@@ -3926,19 +5130,27 @@
                     "key": "1",
                     "bucket": 0.863,
                     "stickyBucketUsed": false
-                }
+                },
+                "ruleId": ""
             }
         ],
         [
             "skip experiment on missing hashAttribute",
             {
-                "attributes": { "id": "123" },
+                "attributes": {
+                    "id": "123"
+                },
                 "features": {
                     "feature": {
                         "defaultValue": 0,
                         "rules": [
                             {
-                                "variations": [ 0, 1, 2, 3 ],
+                                "variations": [
+                                    0,
+                                    1,
+                                    2,
+                                    3
+                                ],
                                 "hashAttribute": "company"
                             },
                             {
@@ -3953,13 +5165,16 @@
                 "value": 3,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
             "include experiments when forced",
             {
-                "attributes": { "id": "123" },
+                "attributes": {
+                    "id": "123"
+                },
                 "forcedVariations": {
                     "feature": 1
                 },
@@ -3968,7 +5183,12 @@
                         "defaultValue": 0,
                         "rules": [
                             {
-                                "variations": [ 0, 1, 2, 3 ]
+                                "variations": [
+                                    0,
+                                    1,
+                                    2,
+                                    3
+                                ]
                             },
                             {
                                 "force": 3
@@ -3985,7 +5205,12 @@
                 "source": "experiment",
                 "experiment": {
                     "key": "feature",
-                    "variations": [ 0, 1, 2, 3 ]
+                    "variations": [
+                        0,
+                        1,
+                        2,
+                        3
+                    ]
                 },
                 "experimentResult": {
                     "featureId": "feature",
@@ -3997,7 +5222,8 @@
                     "hashValue": "123",
                     "key": "1",
                     "stickyBucketUsed": false
-                }
+                },
+                "ruleId": ""
             }
         ],
         [
@@ -4013,7 +5239,10 @@
                             {
                                 "force": 2,
                                 "coverage": 0.01,
-                                "range": [ 0, 0.99 ]
+                                "range": [
+                                    0,
+                                    0.99
+                                ]
                             }
                         ]
                     }
@@ -4024,7 +5253,8 @@
                 "value": 2,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -4040,7 +5270,10 @@
                             {
                                 "force": 2,
                                 "hashVersion": 2,
-                                "range": [ 0.96, 0.97 ]
+                                "range": [
+                                    0.96,
+                                    0.97
+                                ]
                             }
                         ]
                     }
@@ -4051,7 +5284,8 @@
                 "value": 2,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -4066,7 +5300,10 @@
                         "rules": [
                             {
                                 "force": 2,
-                                "range": [ 0, 0.01 ]
+                                "range": [
+                                    0,
+                                    0.01
+                                ]
                             }
                         ]
                     }
@@ -4077,7 +5314,8 @@
                 "value": 0,
                 "on": false,
                 "off": true,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -4095,7 +5333,12 @@
                                 "filters": [
                                     {
                                         "seed": "seed",
-                                        "ranges": [ [ 0, 0.01 ] ]
+                                        "ranges": [
+                                            [
+                                                0,
+                                                0.01
+                                            ]
+                                        ]
                                     }
                                 ]
                             }
@@ -4108,7 +5351,8 @@
                 "value": 0,
                 "on": false,
                 "off": true,
-                "source": "defaultValue"
+                "source": "defaultValue",
+                "ruleId": ""
             }
         ],
         [
@@ -4123,7 +5367,10 @@
                         "rules": [
                             {
                                 "force": 2,
-                                "range": [ 0, 0.5 ],
+                                "range": [
+                                    0,
+                                    0.5
+                                ],
                                 "seed": "fjdslafdsa",
                                 "hashVersion": 2
                             }
@@ -4136,7 +5383,8 @@
                 "value": 2,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -4151,11 +5399,20 @@
                         "rules": [
                             {
                                 "key": "holdout",
-                                "variations": [ 1, 2 ],
+                                "variations": [
+                                    1,
+                                    2
+                                ],
                                 "hashVersion": 2,
                                 "ranges": [
-                                    [ 0, 0.01 ],
-                                    [ 0.01, 1.0 ]
+                                    [
+                                        0,
+                                        0.01
+                                    ],
+                                    [
+                                        0.01,
+                                        1
+                                    ]
                                 ],
                                 "meta": [
                                     {},
@@ -4166,11 +5423,20 @@
                             },
                             {
                                 "key": "experiment",
-                                "variations": [ 3, 4 ],
+                                "variations": [
+                                    3,
+                                    4
+                                ],
                                 "hashVersion": 2,
                                 "ranges": [
-                                    [ 0, 0.5 ],
-                                    [ 0.5, 1.0 ]
+                                    [
+                                        0,
+                                        0.5
+                                    ],
+                                    [
+                                        0.5,
+                                        1
+                                    ]
                                 ]
                             }
                         ]
@@ -4186,10 +5452,19 @@
                 "experiment": {
                     "key": "experiment",
                     "hashVersion": 2,
-                    "variations": [ 3, 4 ],
+                    "variations": [
+                        3,
+                        4
+                    ],
                     "ranges": [
-                        [ 0, 0.5 ],
-                        [ 0.5, 1.0 ]
+                        [
+                            0,
+                            0.5
+                        ],
+                        [
+                            0.5,
+                            1
+                        ]
                     ]
                 },
                 "experimentResult": {
@@ -4203,7 +5478,8 @@
                     "variationId": 0,
                     "bucket": 0.4413,
                     "stickyBucketUsed": false
-                }
+                },
+                "ruleId": ""
             }
         ],
         [
@@ -4219,10 +5495,19 @@
                             {
                                 "key": "holdout",
                                 "hashVersion": 2,
-                                "variations": [ 1, 2 ],
+                                "variations": [
+                                    1,
+                                    2
+                                ],
                                 "ranges": [
-                                    [ 0, 0.99 ],
-                                    [ 0.99, 1.0 ]
+                                    [
+                                        0,
+                                        0.99
+                                    ],
+                                    [
+                                        0.99,
+                                        1
+                                    ]
                                 ],
                                 "meta": [
                                     {},
@@ -4234,10 +5519,19 @@
                             {
                                 "key": "experiment",
                                 "hashVersion": 2,
-                                "variations": [ 3, 4 ],
+                                "variations": [
+                                    3,
+                                    4
+                                ],
                                 "ranges": [
-                                    [ 0, 0.5 ],
-                                    [ 0.5, 1.0 ]
+                                    [
+                                        0,
+                                        0.5
+                                    ],
+                                    [
+                                        0.5,
+                                        1
+                                    ]
                                 ]
                             }
                         ]
@@ -4253,8 +5547,14 @@
                 "experiment": {
                     "hashVersion": 2,
                     "ranges": [
-                        [ 0, 0.99 ],
-                        [ 0.99, 1.0 ]
+                        [
+                            0,
+                            0.99
+                        ],
+                        [
+                            0.99,
+                            1
+                        ]
                     ],
                     "meta": [
                         {},
@@ -4263,7 +5563,10 @@
                         }
                     ],
                     "key": "holdout",
-                    "variations": [ 1, 2 ]
+                    "variations": [
+                        1,
+                        2
+                    ]
                 },
                 "experimentResult": {
                     "featureId": "feature",
@@ -4276,7 +5579,8 @@
                     "variationId": 0,
                     "bucket": 0.8043,
                     "stickyBucketUsed": false
-                }
+                },
+                "ruleId": ""
             }
         ],
         [
@@ -4292,11 +5596,20 @@
                         "defaultValue": "silver",
                         "rules": [
                             {
-                                "condition": { "country": "Canada" },
+                                "condition": {
+                                    "country": "Canada"
+                                },
                                 "force": "red"
                             },
                             {
-                                "condition": { "country": { "$in": [ "USA", "Mexico" ] } },
+                                "condition": {
+                                    "country": {
+                                        "$in": [
+                                            "USA",
+                                            "Mexico"
+                                        ]
+                                    }
+                                },
                                 "force": "green"
                             }
                         ]
@@ -4308,13 +5621,17 @@
                                 "parentConditions": [
                                     {
                                         "id": "parentFlag",
-                                        "condition": { "value": "green" },
+                                        "condition": {
+                                            "value": "green"
+                                        },
                                         "gate": true
                                     }
                                 ]
                             },
                             {
-                                "condition": { "memberType": "basic" },
+                                "condition": {
+                                    "memberType": "basic"
+                                },
                                 "force": "success"
                             }
                         ]
@@ -4326,7 +5643,8 @@
                 "value": null,
                 "on": false,
                 "off": true,
-                "source": "prerequisite"
+                "source": "prerequisite",
+                "ruleId": ""
             }
         ],
         [
@@ -4345,13 +5663,17 @@
                                 "parentConditions": [
                                     {
                                         "id": "parentFlag",
-                                        "condition": { "value": "green" },
+                                        "condition": {
+                                            "value": "green"
+                                        },
                                         "gate": true
                                     }
                                 ]
                             },
                             {
-                                "condition": { "memberType": "basic" },
+                                "condition": {
+                                    "memberType": "basic"
+                                },
                                 "force": "success"
                             }
                         ]
@@ -4363,7 +5685,8 @@
                 "value": null,
                 "on": false,
                 "off": true,
-                "source": "prerequisite"
+                "source": "prerequisite",
+                "ruleId": ""
             }
         ],
         [
@@ -4379,11 +5702,20 @@
                         "defaultValue": "silver",
                         "rules": [
                             {
-                                "condition": { "country": "Canada" },
+                                "condition": {
+                                    "country": "Canada"
+                                },
                                 "force": "red"
                             },
                             {
-                                "condition": { "country": { "$in": [ "USA", "Mexico" ] } },
+                                "condition": {
+                                    "country": {
+                                        "$in": [
+                                            "USA",
+                                            "Mexico"
+                                        ]
+                                    }
+                                },
                                 "force": "green"
                             }
                         ]
@@ -4395,13 +5727,17 @@
                                 "parentConditions": [
                                     {
                                         "id": "parentFlag",
-                                        "condition": { "value": "green" },
+                                        "condition": {
+                                            "value": "green"
+                                        },
                                         "gate": true
                                     }
                                 ]
                             },
                             {
-                                "condition": { "memberType": "basic" },
+                                "condition": {
+                                    "memberType": "basic"
+                                },
                                 "force": "success"
                             }
                         ]
@@ -4413,7 +5749,8 @@
                 "value": "success",
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -4429,11 +5766,20 @@
                         "defaultValue": "silver",
                         "rules": [
                             {
-                                "condition": { "country": "Canada" },
+                                "condition": {
+                                    "country": "Canada"
+                                },
                                 "force": "red"
                             },
                             {
-                                "condition": { "country": { "$in": [ "USA", "Mexico" ] } },
+                                "condition": {
+                                    "country": {
+                                        "$in": [
+                                            "USA",
+                                            "Mexico"
+                                        ]
+                                    }
+                                },
                                 "force": "green"
                             }
                         ]
@@ -4442,7 +5788,9 @@
                         "defaultValue": 0,
                         "rules": [
                             {
-                                "condition": { "id": "123" },
+                                "condition": {
+                                    "id": "123"
+                                },
                                 "force": 2
                             }
                         ]
@@ -4454,7 +5802,9 @@
                                 "parentConditions": [
                                     {
                                         "id": "parentFlag1",
-                                        "condition": { "value": "green" },
+                                        "condition": {
+                                            "value": "green"
+                                        },
                                         "gate": true
                                     }
                                 ]
@@ -4463,13 +5813,19 @@
                                 "parentConditions": [
                                     {
                                         "id": "parentFlag2",
-                                        "condition": { "value": { "$gt": 1 } },
+                                        "condition": {
+                                            "value": {
+                                                "$gt": 1
+                                            }
+                                        },
                                         "gate": true
                                     }
                                 ]
                             },
                             {
-                                "condition": { "memberType": "basic" },
+                                "condition": {
+                                    "memberType": "basic"
+                                },
                                 "force": "success"
                             }
                         ]
@@ -4481,7 +5837,8 @@
                 "value": "success",
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -4500,17 +5857,30 @@
                                 "parentConditions": [
                                     {
                                         "id": "parentFlag2",
-                                        "condition": { "value": { "$gt": 1 } },
+                                        "condition": {
+                                            "value": {
+                                                "$gt": 1
+                                            }
+                                        },
                                         "gate": true
                                     }
                                 ]
                             },
                             {
-                                "condition": { "country": "Canada" },
+                                "condition": {
+                                    "country": "Canada"
+                                },
                                 "force": "red"
                             },
                             {
-                                "condition": { "country": { "$in": [ "USA", "Mexico" ] } },
+                                "condition": {
+                                    "country": {
+                                        "$in": [
+                                            "USA",
+                                            "Mexico"
+                                        ]
+                                    }
+                                },
                                 "force": "green"
                             }
                         ]
@@ -4519,7 +5889,9 @@
                         "defaultValue": 0,
                         "rules": [
                             {
-                                "condition": { "id": "123" },
+                                "condition": {
+                                    "id": "123"
+                                },
                                 "force": 2
                             }
                         ]
@@ -4531,13 +5903,17 @@
                                 "parentConditions": [
                                     {
                                         "id": "parentFlag1",
-                                        "condition": { "value": "green" },
+                                        "condition": {
+                                            "value": "green"
+                                        },
                                         "gate": true
                                     }
                                 ]
                             },
                             {
-                                "condition": { "memberType": "basic" },
+                                "condition": {
+                                    "memberType": "basic"
+                                },
                                 "force": "success"
                             }
                         ]
@@ -4549,7 +5925,8 @@
                 "value": "success",
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -4566,12 +5943,21 @@
                         "rules": [
                             {
                                 "key": "experiment",
-                                "variations": [ 0, 1 ],
+                                "variations": [
+                                    0,
+                                    1
+                                ],
                                 "hashAttribute": "id",
                                 "hashVersion": 2,
                                 "ranges": [
-                                    [ 0, 0.5 ],
-                                    [ 0.5, 1.0 ]
+                                    [
+                                        0,
+                                        0.5
+                                    ],
+                                    [
+                                        0.5,
+                                        1
+                                    ]
                                 ]
                             }
                         ]
@@ -4583,13 +5969,17 @@
                                 "parentConditions": [
                                     {
                                         "id": "parentExperimentFlag",
-                                        "condition": { "value": 1 },
+                                        "condition": {
+                                            "value": 1
+                                        },
                                         "gate": true
                                     }
                                 ]
                             },
                             {
-                                "condition": { "memberType": "basic" },
+                                "condition": {
+                                    "memberType": "basic"
+                                },
                                 "force": "success"
                             }
                         ]
@@ -4601,7 +5991,74 @@
                 "value": "success",
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
+            }
+        ],
+        [
+            "Prerequisite experiment flag in target bucket, evaluate skip dependent flag if not bucketed",
+            {
+                "attributes": {
+                    "id": "1234",
+                    "memberType": "basic",
+                    "country": "USA"
+                },
+                "features": {
+                    "parentExperimentFlag": {
+                        "defaultValue": 0,
+                        "rules": [
+                            {
+                                "key": "experiment",
+                                "variations": [
+                                    0,
+                                    1
+                                ],
+                                "hashAttribute": "id",
+                                "hashVersion": 2,
+                                "ranges": [
+                                    [
+                                        0,
+                                        0.5
+                                    ],
+                                    [
+                                        0.5,
+                                        1
+                                    ]
+                                ]
+                            }
+                        ]
+                    },
+                    "childFlag": {
+                        "defaultValue": "default",
+                        "rules": [
+                            {
+                                "parentConditions": [
+                                    {
+                                        "id": "parentExperimentFlag",
+                                        "condition": {
+                                            "value": 0
+                                        },
+                                        "gate": true
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": {
+                                    "memberType": "basic"
+                                },
+                                "force": "success"
+                            }
+                        ]
+                    }
+                }
+            },
+            "childFlag",
+            {
+                "value": null,
+                "on": false,
+                "off": true,
+                "source": "prerequisite",
+                "ruleId": ""
             }
         ],
         [
@@ -4618,7 +6075,9 @@
                                 "parentConditions": [
                                     {
                                         "id": "flag2",
-                                        "condition": { "value": true },
+                                        "condition": {
+                                            "value": true
+                                        },
                                         "gate": true
                                     }
                                 ]
@@ -4632,7 +6091,9 @@
                                 "parentConditions": [
                                     {
                                         "id": "flag1",
-                                        "condition": { "value": true },
+                                        "condition": {
+                                            "value": true
+                                        },
                                         "gate": true
                                     }
                                 ]
@@ -4646,7 +6107,85 @@
                 "value": null,
                 "on": false,
                 "off": true,
-                "source": "cyclicPrerequisite"
+                "source": "cyclicPrerequisite",
+                "ruleId": ""
+            }
+        ],
+        [
+            "Multiple references to same prerequisite, do not break",
+            {
+                "attributes": {
+                    "id": "123",
+                    "browser": "edge"
+                },
+                "features": {
+                    "childFlag": {
+                        "defaultValue": true,
+                        "rules": [
+                            {
+                                "parentConditions": [
+                                    {
+                                        "id": "parentFlag",
+                                        "condition": {
+                                            "value": {
+                                                "$ne": false
+                                            }
+                                        },
+                                        "gate": true
+                                    },
+                                    {
+                                        "id": "parentFlag",
+                                        "condition": {
+                                            "value": true
+                                        },
+                                        "gate": true
+                                    }
+                                ]
+                            },
+                            {
+                                "condition": {
+                                    "browser": "safari"
+                                },
+                                "parentConditions": [
+                                    {
+                                        "id": "parentFlag",
+                                        "condition": {
+                                            "value": true
+                                        }
+                                    }
+                                ],
+                                "force": "C"
+                            },
+                            {
+                                "condition": {
+                                    "browser": {
+                                        "$ne": "safari"
+                                    }
+                                },
+                                "parentConditions": [
+                                    {
+                                        "id": "parentFlag",
+                                        "condition": {
+                                            "value": true
+                                        }
+                                    }
+                                ],
+                                "force": "T"
+                            }
+                        ]
+                    },
+                    "parentFlag": {
+                        "defaultValue": true
+                    }
+                }
+            },
+            "childFlag",
+            {
+                "value": "T",
+                "on": true,
+                "off": false,
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -4661,13 +6200,20 @@
                         "rules": [
                             {
                                 "force": true,
-                                "condition": { "id": { "$inGroup": "group_id" } }
+                                "condition": {
+                                    "id": {
+                                        "$inGroup": "group_id"
+                                    }
+                                }
                             }
                         ]
                     }
                 },
                 "savedGroups": {
-                    "group_id": [ 123, 456 ]
+                    "group_id": [
+                        123,
+                        456
+                    ]
                 }
             },
             "inGroup_force_rule",
@@ -4675,7 +6221,8 @@
                 "value": true,
                 "on": true,
                 "off": false,
-                "source": "force"
+                "source": "force",
+                "ruleId": ""
             }
         ],
         [
@@ -4690,19 +6237,35 @@
                         "rules": [
                             {
                                 "key": "experiment",
-                                "condition": { "id": { "$inGroup": "group_id" } },
+                                "condition": {
+                                    "id": {
+                                        "$inGroup": "group_id"
+                                    }
+                                },
                                 "hashVersion": 2,
-                                "variations": [ 1, 2 ],
+                                "variations": [
+                                    1,
+                                    2
+                                ],
                                 "ranges": [
-                                    [ 0, 0.5 ],
-                                    [ 0.5, 1.0 ]
+                                    [
+                                        0,
+                                        0.5
+                                    ],
+                                    [
+                                        0.5,
+                                        1
+                                    ]
                                 ]
                             }
                         ]
                     }
                 },
                 "savedGroups": {
-                    "group_id": [ 123, 456 ]
+                    "group_id": [
+                        123,
+                        456
+                    ]
                 }
             },
             "inGroup_experiment_rule",
@@ -4713,11 +6276,24 @@
                 "source": "experiment",
                 "experiment": {
                     "hashVersion": 2,
-                    "condition": { "id": { "$inGroup": "group_id" } },
-                    "variations": [ 1, 2 ],
+                    "condition": {
+                        "id": {
+                            "$inGroup": "group_id"
+                        }
+                    },
+                    "variations": [
+                        1,
+                        2
+                    ],
                     "ranges": [
-                        [ 0, 0.5 ],
-                        [ 0.5, 1.0 ]
+                        [
+                            0,
+                            0.5
+                        ],
+                        [
+                            0.5,
+                            1
+                        ]
                     ],
                     "key": "experiment"
                 },
@@ -4732,17 +6308,25 @@
                     "variationId": 0,
                     "bucket": 0.1736,
                     "stickyBucketUsed": false
-                }
+                },
+                "ruleId": ""
             }
         ]
     ],
     "run": [
         [
             "default weights - 1",
-            { "attributes": { "id": "1" } },
+            {
+                "attributes": {
+                    "id": "1"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             1,
             true,
@@ -4750,10 +6334,17 @@
         ],
         [
             "default weights - 2",
-            { "attributes": { "id": "2" } },
+            {
+                "attributes": {
+                    "id": "2"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             0,
             true,
@@ -4761,10 +6352,17 @@
         ],
         [
             "default weights - 3",
-            { "attributes": { "id": "3" } },
+            {
+                "attributes": {
+                    "id": "3"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             0,
             true,
@@ -4772,10 +6370,17 @@
         ],
         [
             "default weights - 4",
-            { "attributes": { "id": "4" } },
+            {
+                "attributes": {
+                    "id": "4"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             1,
             true,
@@ -4783,10 +6388,17 @@
         ],
         [
             "default weights - 5",
-            { "attributes": { "id": "5" } },
+            {
+                "attributes": {
+                    "id": "5"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             1,
             true,
@@ -4794,10 +6406,17 @@
         ],
         [
             "default weights - 6",
-            { "attributes": { "id": "6" } },
+            {
+                "attributes": {
+                    "id": "6"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             1,
             true,
@@ -4805,10 +6424,17 @@
         ],
         [
             "default weights - 7",
-            { "attributes": { "id": "7" } },
+            {
+                "attributes": {
+                    "id": "7"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             0,
             true,
@@ -4816,10 +6442,17 @@
         ],
         [
             "default weights - 8",
-            { "attributes": { "id": "8" } },
+            {
+                "attributes": {
+                    "id": "8"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             1,
             true,
@@ -4827,10 +6460,17 @@
         ],
         [
             "default weights - 9",
-            { "attributes": { "id": "9" } },
+            {
+                "attributes": {
+                    "id": "9"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             0,
             true,
@@ -4838,11 +6478,21 @@
         ],
         [
             "uneven weights - 1",
-            { "attributes": { "id": "1" } },
+            {
+                "attributes": {
+                    "id": "1"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
+                "variations": [
+                    0,
+                    1
+                ],
+                "weights": [
+                    0.1,
+                    0.9
+                ]
             },
             1,
             true,
@@ -4850,11 +6500,21 @@
         ],
         [
             "uneven weights - 2",
-            { "attributes": { "id": "2" } },
+            {
+                "attributes": {
+                    "id": "2"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
+                "variations": [
+                    0,
+                    1
+                ],
+                "weights": [
+                    0.1,
+                    0.9
+                ]
             },
             1,
             true,
@@ -4862,11 +6522,21 @@
         ],
         [
             "uneven weights - 3",
-            { "attributes": { "id": "3" } },
+            {
+                "attributes": {
+                    "id": "3"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
+                "variations": [
+                    0,
+                    1
+                ],
+                "weights": [
+                    0.1,
+                    0.9
+                ]
             },
             0,
             true,
@@ -4874,11 +6544,21 @@
         ],
         [
             "uneven weights - 4",
-            { "attributes": { "id": "4" } },
+            {
+                "attributes": {
+                    "id": "4"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
+                "variations": [
+                    0,
+                    1
+                ],
+                "weights": [
+                    0.1,
+                    0.9
+                ]
             },
             1,
             true,
@@ -4886,11 +6566,21 @@
         ],
         [
             "uneven weights - 5",
-            { "attributes": { "id": "5" } },
+            {
+                "attributes": {
+                    "id": "5"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
+                "variations": [
+                    0,
+                    1
+                ],
+                "weights": [
+                    0.1,
+                    0.9
+                ]
             },
             1,
             true,
@@ -4898,11 +6588,21 @@
         ],
         [
             "uneven weights - 6",
-            { "attributes": { "id": "6" } },
+            {
+                "attributes": {
+                    "id": "6"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
+                "variations": [
+                    0,
+                    1
+                ],
+                "weights": [
+                    0.1,
+                    0.9
+                ]
             },
             1,
             true,
@@ -4910,11 +6610,21 @@
         ],
         [
             "uneven weights - 7",
-            { "attributes": { "id": "7" } },
+            {
+                "attributes": {
+                    "id": "7"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
+                "variations": [
+                    0,
+                    1
+                ],
+                "weights": [
+                    0.1,
+                    0.9
+                ]
             },
             0,
             true,
@@ -4922,11 +6632,21 @@
         ],
         [
             "uneven weights - 8",
-            { "attributes": { "id": "8" } },
+            {
+                "attributes": {
+                    "id": "8"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
+                "variations": [
+                    0,
+                    1
+                ],
+                "weights": [
+                    0.1,
+                    0.9
+                ]
             },
             1,
             true,
@@ -4934,11 +6654,21 @@
         ],
         [
             "uneven weights - 9",
-            { "attributes": { "id": "9" } },
+            {
+                "attributes": {
+                    "id": "9"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
-                "weights": [ 0.1, 0.9 ]
+                "variations": [
+                    0,
+                    1
+                ],
+                "weights": [
+                    0.1,
+                    0.9
+                ]
             },
             1,
             true,
@@ -4946,10 +6676,17 @@
         ],
         [
             "coverage - 1",
-            { "attributes": { "id": "1" } },
+            {
+                "attributes": {
+                    "id": "1"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "coverage": 0.4
             },
             0,
@@ -4958,10 +6695,17 @@
         ],
         [
             "coverage - 2",
-            { "attributes": { "id": "2" } },
+            {
+                "attributes": {
+                    "id": "2"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "coverage": 0.4
             },
             0,
@@ -4970,10 +6714,17 @@
         ],
         [
             "coverage - 3",
-            { "attributes": { "id": "3" } },
+            {
+                "attributes": {
+                    "id": "3"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "coverage": 0.4
             },
             0,
@@ -4982,10 +6733,17 @@
         ],
         [
             "coverage - 4",
-            { "attributes": { "id": "4" } },
+            {
+                "attributes": {
+                    "id": "4"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "coverage": 0.4
             },
             0,
@@ -4994,10 +6752,17 @@
         ],
         [
             "coverage - 5",
-            { "attributes": { "id": "5" } },
+            {
+                "attributes": {
+                    "id": "5"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "coverage": 0.4
             },
             1,
@@ -5006,10 +6771,17 @@
         ],
         [
             "coverage - 6",
-            { "attributes": { "id": "6" } },
+            {
+                "attributes": {
+                    "id": "6"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "coverage": 0.4
             },
             0,
@@ -5018,10 +6790,17 @@
         ],
         [
             "coverage - 7",
-            { "attributes": { "id": "7" } },
+            {
+                "attributes": {
+                    "id": "7"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "coverage": 0.4
             },
             0,
@@ -5030,10 +6809,17 @@
         ],
         [
             "coverage - 8",
-            { "attributes": { "id": "8" } },
+            {
+                "attributes": {
+                    "id": "8"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "coverage": 0.4
             },
             1,
@@ -5042,10 +6828,17 @@
         ],
         [
             "coverage - 9",
-            { "attributes": { "id": "9" } },
+            {
+                "attributes": {
+                    "id": "9"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "coverage": 0.4
             },
             0,
@@ -5054,10 +6847,18 @@
         ],
         [
             "three way test - 1",
-            { "attributes": { "id": "1" } },
+            {
+                "attributes": {
+                    "id": "1"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1, 2 ]
+                "variations": [
+                    0,
+                    1,
+                    2
+                ]
             },
             2,
             true,
@@ -5065,10 +6866,18 @@
         ],
         [
             "three way test - 2",
-            { "attributes": { "id": "2" } },
+            {
+                "attributes": {
+                    "id": "2"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1, 2 ]
+                "variations": [
+                    0,
+                    1,
+                    2
+                ]
             },
             0,
             true,
@@ -5076,10 +6885,18 @@
         ],
         [
             "three way test - 3",
-            { "attributes": { "id": "3" } },
+            {
+                "attributes": {
+                    "id": "3"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1, 2 ]
+                "variations": [
+                    0,
+                    1,
+                    2
+                ]
             },
             0,
             true,
@@ -5087,10 +6904,18 @@
         ],
         [
             "three way test - 4",
-            { "attributes": { "id": "4" } },
+            {
+                "attributes": {
+                    "id": "4"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1, 2 ]
+                "variations": [
+                    0,
+                    1,
+                    2
+                ]
             },
             2,
             true,
@@ -5098,10 +6923,18 @@
         ],
         [
             "three way test - 5",
-            { "attributes": { "id": "5" } },
+            {
+                "attributes": {
+                    "id": "5"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1, 2 ]
+                "variations": [
+                    0,
+                    1,
+                    2
+                ]
             },
             1,
             true,
@@ -5109,10 +6942,18 @@
         ],
         [
             "three way test - 6",
-            { "attributes": { "id": "6" } },
+            {
+                "attributes": {
+                    "id": "6"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1, 2 ]
+                "variations": [
+                    0,
+                    1,
+                    2
+                ]
             },
             2,
             true,
@@ -5120,10 +6961,18 @@
         ],
         [
             "three way test - 7",
-            { "attributes": { "id": "7" } },
+            {
+                "attributes": {
+                    "id": "7"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1, 2 ]
+                "variations": [
+                    0,
+                    1,
+                    2
+                ]
             },
             0,
             true,
@@ -5131,10 +6980,18 @@
         ],
         [
             "three way test - 8",
-            { "attributes": { "id": "8" } },
+            {
+                "attributes": {
+                    "id": "8"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1, 2 ]
+                "variations": [
+                    0,
+                    1,
+                    2
+                ]
             },
             1,
             true,
@@ -5142,10 +6999,18 @@
         ],
         [
             "three way test - 9",
-            { "attributes": { "id": "9" } },
+            {
+                "attributes": {
+                    "id": "9"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1, 2 ]
+                "variations": [
+                    0,
+                    1,
+                    2
+                ]
             },
             0,
             true,
@@ -5153,10 +7018,17 @@
         ],
         [
             "test name - my-test",
-            { "attributes": { "id": "1" } },
+            {
+                "attributes": {
+                    "id": "1"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             1,
             true,
@@ -5164,10 +7036,17 @@
         ],
         [
             "test name - my-test-3",
-            { "attributes": { "id": "1" } },
+            {
+                "attributes": {
+                    "id": "1"
+                }
+            },
             {
                 "key": "my-test-3",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             0,
             true,
@@ -5175,10 +7054,17 @@
         ],
         [
             "empty id",
-            { "attributes": { "id": "" } },
+            {
+                "attributes": {
+                    "id": ""
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             0,
             false,
@@ -5186,10 +7072,17 @@
         ],
         [
             "null id",
-            { "attributes": { "id": null } },
+            {
+                "attributes": {
+                    "id": null
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             0,
             false,
@@ -5197,10 +7090,15 @@
         ],
         [
             "missing id",
-            { "attributes": {} },
+            {
+                "attributes": {}
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             0,
             false,
@@ -5211,7 +7109,10 @@
             {},
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             0,
             false,
@@ -5219,10 +7120,16 @@
         ],
         [
             "single variation",
-            { "attributes": { "id": "1" } },
+            {
+                "attributes": {
+                    "id": "1"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0 ]
+                "variations": [
+                    0
+                ]
             },
             0,
             false,
@@ -5230,10 +7137,17 @@
         ],
         [
             "negative forced variation",
-            { "attributes": { "id": "1" } },
+            {
+                "attributes": {
+                    "id": "1"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "force": -8
             },
             0,
@@ -5242,10 +7156,17 @@
         ],
         [
             "high forced variation",
-            { "attributes": { "id": "1" } },
+            {
+                "attributes": {
+                    "id": "1"
+                }
+            },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "force": 25
             },
             0,
@@ -5262,7 +7183,10 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "condition": {
                     "browser": "firefox"
                 }
@@ -5281,7 +7205,10 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "condition": {
                     "browser": "firefox"
                 }
@@ -5300,7 +7227,10 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "hashAttribute": "companyId"
             },
             1,
@@ -5317,7 +7247,10 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             0,
             false,
@@ -5333,7 +7266,10 @@
             },
             {
                 "key": "forced-test-qs",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             1,
             true,
@@ -5349,7 +7285,10 @@
             {
                 "key": "my-test",
                 "active": true,
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             1,
             true,
@@ -5365,7 +7304,10 @@
             {
                 "key": "my-test",
                 "active": false,
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             0,
             false,
@@ -5382,7 +7324,10 @@
             {
                 "key": "my-test",
                 "active": false,
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             1,
             true,
@@ -5399,7 +7344,10 @@
                 "key": "my-test",
                 "force": 1,
                 "coverage": 0.01,
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             0,
             false,
@@ -5435,12 +7383,19 @@
         [
             "Force variation from context",
             {
-                "attributes": { "id": "1" },
-                "forcedVariations": { "my-test": 0 }
+                "attributes": {
+                    "id": "1"
+                },
+                "forcedVariations": {
+                    "my-test": 0
+                }
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             0,
             true,
@@ -5449,12 +7404,17 @@
         [
             "Skips experiments in QA mode",
             {
-                "attributes": { "id": "1" },
+                "attributes": {
+                    "id": "1"
+                },
                 "qaMode": true
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             0,
             false,
@@ -5463,13 +7423,20 @@
         [
             "Works in QA mode if forced in context",
             {
-                "attributes": { "id": "1" },
+                "attributes": {
+                    "id": "1"
+                },
                 "qaMode": true,
-                "forcedVariations": { "my-test": 1 }
+                "forcedVariations": {
+                    "my-test": 1
+                }
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             1,
             true,
@@ -5478,12 +7445,17 @@
         [
             "Works in QA mode if forced in experiment",
             {
-                "attributes": { "id": "1" },
+                "attributes": {
+                    "id": "1"
+                },
                 "qaMode": true
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "force": 1
             },
             1,
@@ -5499,8 +7471,15 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
-                "namespace": [ "namespace", 0.1, 1 ]
+                "variations": [
+                    0,
+                    1
+                ],
+                "namespace": [
+                    "namespace",
+                    0.1,
+                    1
+                ]
             },
             1,
             true,
@@ -5515,8 +7494,15 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
-                "namespace": [ "namespace", 0, 0.1 ]
+                "variations": [
+                    0,
+                    1
+                ],
+                "namespace": [
+                    "namespace",
+                    0,
+                    0.1
+                ]
             },
             0,
             false,
@@ -5531,7 +7517,10 @@
             },
             {
                 "key": "no-coverage",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "coverage": 0
             },
             0,
@@ -5548,19 +7537,33 @@
             },
             {
                 "key": "filtered",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "filters": [
                     {
                         "seed": "seed",
                         "ranges": [
-                            [ 0, 0.1 ],
-                            [ 0.2, 0.4 ]
+                            [
+                                0,
+                                0.1
+                            ],
+                            [
+                                0.2,
+                                0.4
+                            ]
                         ]
                     },
                     {
                         "seed": "seed",
                         "attribute": "anonId",
-                        "ranges": [ [ 0.8, 1.0 ] ]
+                        "ranges": [
+                            [
+                                0.8,
+                                1
+                            ]
+                        ]
                     }
                 ]
             },
@@ -5578,19 +7581,33 @@
             },
             {
                 "key": "filtered",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "filters": [
                     {
                         "seed": "seed",
                         "ranges": [
-                            [ 0, 0.1 ],
-                            [ 0.2, 0.4 ]
+                            [
+                                0,
+                                0.1
+                            ],
+                            [
+                                0.2,
+                                0.4
+                            ]
                         ]
                     },
                     {
                         "seed": "seed",
                         "attribute": "anonId",
-                        "ranges": [ [ 0.6, 0.8 ] ]
+                        "ranges": [
+                            [
+                                0.6,
+                                0.8
+                            ]
+                        ]
                     }
                 ]
             },
@@ -5607,17 +7624,30 @@
             },
             {
                 "key": "filtered",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "filters": [
                     {
                         "seed": "seed",
                         "ranges": [
-                            [ 0, 0.1 ],
-                            [ 0.2, 0.4 ]
+                            [
+                                0,
+                                0.1
+                            ],
+                            [
+                                0.2,
+                                0.4
+                            ]
                         ]
                     }
                 ],
-                "namespace": [ "test", 0, 0.001 ]
+                "namespace": [
+                    "test",
+                    0,
+                    0.001
+                ]
             },
             1,
             true,
@@ -5632,13 +7662,25 @@
             },
             {
                 "key": "ranges",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "ranges": [
-                    [ 0.99, 1.0 ],
-                    [ 0.0, 0.99 ]
+                    [
+                        0.99,
+                        1
+                    ],
+                    [
+                        0,
+                        0.99
+                    ]
                 ],
                 "coverage": 0.01,
-                "weights": [ 0.99, 0.01 ]
+                "weights": [
+                    0.99,
+                    0.01
+                ]
             },
             1,
             true,
@@ -5653,10 +7695,19 @@
             },
             {
                 "key": "configs",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "ranges": [
-                    [ 0, 0.1 ],
-                    [ 0.9, 1.0 ]
+                    [
+                        0,
+                        0.1
+                    ],
+                    [
+                        0.9,
+                        1
+                    ]
                 ]
             },
             0,
@@ -5674,10 +7725,19 @@
                 "key": "key",
                 "seed": "foo",
                 "hashVersion": 2,
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "ranges": [
-                    [ 0, 0.5 ],
-                    [ 0.5, 1.0 ]
+                    [
+                        0,
+                        0.5
+                    ],
+                    [
+                        0.5,
+                        1
+                    ]
                 ]
             },
             1,
@@ -5695,7 +7755,10 @@
                 "key": "key",
                 "seed": "foo",
                 "hashVersion": 2,
-                "variations": [ 0, 1 ]
+                "variations": [
+                    0,
+                    1
+                ]
             },
             1,
             true,
@@ -5712,8 +7775,14 @@
                 "key": "key",
                 "seed": "foo",
                 "hashVersion": 2,
-                "variations": [ 0, 1 ],
-                "weights": [ 0.5, 0.5 ],
+                "variations": [
+                    0,
+                    1
+                ],
+                "weights": [
+                    0.5,
+                    0.5
+                ],
                 "coverage": 0.99
             },
             1,
@@ -5723,7 +7792,9 @@
         [
             "Prerequisite condition passes",
             {
-                "attributes": { "id": "1" },
+                "attributes": {
+                    "id": "1"
+                },
                 "features": {
                     "parentFlag": {
                         "defaultValue": true
@@ -5732,7 +7803,10 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "parentConditions": [
                     {
                         "id": "parentFlag",
@@ -5749,7 +7823,9 @@
         [
             "Prerequisite condition fails",
             {
-                "attributes": { "id": "1" },
+                "attributes": {
+                    "id": "1"
+                },
                 "features": {
                     "parentFlag": {
                         "defaultValue": false
@@ -5758,7 +7834,10 @@
             },
             {
                 "key": "my-test",
-                "variations": [ 0, 1 ],
+                "variations": [
+                    0,
+                    1
+                ],
                 "parentConditions": [
                     {
                         "id": "parentFlag",
@@ -5775,15 +7854,29 @@
         [
             "SavedGroups correctly pulled from context for experiment",
             {
-                "attributes": { "id": "4" },
-                "savedGroups": { "group_id": [ "4", "5", "6" ] }
+                "attributes": {
+                    "id": "4"
+                },
+                "savedGroups": {
+                    "group_id": [
+                        "4",
+                        "5",
+                        "6"
+                    ]
+                }
             },
             {
                 "key": "group-filtered-test",
                 "condition": {
-                    "id": { "$inGroup": "group_id" }
+                    "id": {
+                        "$inGroup": "group_id"
+                    }
                 },
-                "variations": [ 0, 1, 2 ]
+                "variations": [
+                    0,
+                    1,
+                    2
+                ]
             },
             0,
             true,
@@ -5795,8 +7888,14 @@
             "even range, 0.2",
             0.2,
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [
+                    0,
+                    0.5
+                ],
+                [
+                    0.5,
+                    1
+                ]
             ],
             0
         ],
@@ -5804,8 +7903,14 @@
             "even range, 0.4",
             0.4,
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [
+                    0,
+                    0.5
+                ],
+                [
+                    0.5,
+                    1
+                ]
             ],
             0
         ],
@@ -5813,8 +7918,14 @@
             "even range, 0.6",
             0.6,
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [
+                    0,
+                    0.5
+                ],
+                [
+                    0.5,
+                    1
+                ]
             ],
             1
         ],
@@ -5822,8 +7933,14 @@
             "even range, 0.8",
             0.8,
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [
+                    0,
+                    0.5
+                ],
+                [
+                    0.5,
+                    1
+                ]
             ],
             1
         ],
@@ -5831,8 +7948,14 @@
             "even range, 0",
             0,
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [
+                    0,
+                    0.5
+                ],
+                [
+                    0.5,
+                    1
+                ]
             ],
             0
         ],
@@ -5840,8 +7963,14 @@
             "even range, 0.5",
             0.5,
             [
-                [ 0, 0.5 ],
-                [ 0.5, 1 ]
+                [
+                    0,
+                    0.5
+                ],
+                [
+                    0.5,
+                    1
+                ]
             ],
             1
         ],
@@ -5849,8 +7978,14 @@
             "reduced range, 0.2",
             0.2,
             [
-                [ 0, 0.25 ],
-                [ 0.5, 0.75 ]
+                [
+                    0,
+                    0.25
+                ],
+                [
+                    0.5,
+                    0.75
+                ]
             ],
             0
         ],
@@ -5858,8 +7993,14 @@
             "reduced range, 0.4",
             0.4,
             [
-                [ 0, 0.25 ],
-                [ 0.5, 0.75 ]
+                [
+                    0,
+                    0.25
+                ],
+                [
+                    0.5,
+                    0.75
+                ]
             ],
             -1
         ],
@@ -5867,8 +8008,14 @@
             "reduced range, 0.6",
             0.6,
             [
-                [ 0, 0.25 ],
-                [ 0.5, 0.75 ]
+                [
+                    0,
+                    0.25
+                ],
+                [
+                    0.5,
+                    0.75
+                ]
             ],
             1
         ],
@@ -5876,8 +8023,14 @@
             "reduced range, 0.8",
             0.8,
             [
-                [ 0, 0.25 ],
-                [ 0.5, 0.75 ]
+                [
+                    0,
+                    0.25
+                ],
+                [
+                    0.5,
+                    0.75
+                ]
             ],
             -1
         ],
@@ -5885,8 +8038,14 @@
             "reduced range, 0.25",
             0.25,
             [
-                [ 0, 0.25 ],
-                [ 0.5, 0.75 ]
+                [
+                    0,
+                    0.25
+                ],
+                [
+                    0.5,
+                    0.75
+                ]
             ],
             -1
         ],
@@ -5894,8 +8053,14 @@
             "reduced range, 0.5",
             0.5,
             [
-                [ 0, 0.25 ],
-                [ 0.5, 0.75 ]
+                [
+                    0,
+                    0.25
+                ],
+                [
+                    0.5,
+                    0.75
+                ]
             ],
             1
         ],
@@ -5903,17 +8068,44 @@
             "zero range",
             0.5,
             [
-                [ 0, 0.5 ],
-                [ 0.5, 0.5 ],
-                [ 0.5, 1 ]
+                [
+                    0,
+                    0.5
+                ],
+                [
+                    0.5,
+                    0.5
+                ],
+                [
+                    0.5,
+                    1
+                ]
             ],
             2
         ]
     ],
     "getQueryStringOverride": [
-        [ "empty url", "my-test", "", 2, null ],
-        [ "no query string", "my-test", "http://example.com", 2, null ],
-        [ "empty query string", "my-test", "http://example.com?", 2, null ],
+        [
+            "empty url",
+            "my-test",
+            "",
+            2,
+            null
+        ],
+        [
+            "no query string",
+            "my-test",
+            "http://example.com",
+            2,
+            null
+        ],
+        [
+            "empty query string",
+            "my-test",
+            "http://example.com?",
+            2,
+            null
+        ],
         [
             "no query string match",
             "my-test",
@@ -5921,14 +8113,62 @@
             2,
             null
         ],
-        [ "invalid query string", "my-test", "http://example.com??&&&?#", 2, null ],
-        [ "simple match 0", "my-test", "http://example.com?my-test=0", 2, 0 ],
-        [ "simple match 1", "my-test", "http://example.com?my-test=1", 2, 1 ],
-        [ "negative variation", "my-test", "http://example.com?my-test=-1", 2, null ],
-        [ "float", "my-test", "http://example.com?my-test=2.054", 2, null ],
-        [ "string", "my-test", "http://example.com?my-test=foo", 2, null ],
-        [ "variation too high", "my-test", "http://example.com?my-test=5", 2, null ],
-        [ "high numVariations", "my-test", "http://example.com?my-test=5", 6, 5 ],
+        [
+            "invalid query string",
+            "my-test",
+            "http://example.com??&&&?#",
+            2,
+            null
+        ],
+        [
+            "simple match 0",
+            "my-test",
+            "http://example.com?my-test=0",
+            2,
+            0
+        ],
+        [
+            "simple match 1",
+            "my-test",
+            "http://example.com?my-test=1",
+            2,
+            1
+        ],
+        [
+            "negative variation",
+            "my-test",
+            "http://example.com?my-test=-1",
+            2,
+            null
+        ],
+        [
+            "float",
+            "my-test",
+            "http://example.com?my-test=2.054",
+            2,
+            null
+        ],
+        [
+            "string",
+            "my-test",
+            "http://example.com?my-test=foo",
+            2,
+            null
+        ],
+        [
+            "variation too high",
+            "my-test",
+            "http://example.com?my-test=5",
+            2,
+            null
+        ],
+        [
+            "high numVariations",
+            "my-test",
+            "http://example.com?my-test=5",
+            6,
+            5
+        ],
         [
             "equal to numVariations",
             "my-test",
@@ -5950,103 +8190,173 @@
             2,
             1
         ],
-        [ "anchor", "my-test", "http://example.com?my-test=1#foo", 2, 1 ]
+        [
+            "anchor",
+            "my-test",
+            "http://example.com?my-test=1#foo",
+            2,
+            1
+        ]
     ],
     "inNamespace": [
         [
             "user 1, namespace1, 1",
             "1",
-            [ "namespace1", 0, 0.4 ],
+            [
+                "namespace1",
+                0,
+                0.4
+            ],
             false
         ],
         [
             "user 1, namespace1, 2",
             "1",
-            [ "namespace1", 0.4, 1 ],
+            [
+                "namespace1",
+                0.4,
+                1
+            ],
             true
         ],
         [
             "user 1, namespace2, 1",
             "1",
-            [ "namespace2", 0, 0.4 ],
+            [
+                "namespace2",
+                0,
+                0.4
+            ],
             false
         ],
         [
             "user 1, namespace2, 2",
             "1",
-            [ "namespace2", 0.4, 1 ],
+            [
+                "namespace2",
+                0.4,
+                1
+            ],
             true
         ],
         [
             "user 2, namespace1, 1",
             "2",
-            [ "namespace1", 0, 0.4 ],
+            [
+                "namespace1",
+                0,
+                0.4
+            ],
             false
         ],
         [
             "user 2, namespace1, 2",
             "2",
-            [ "namespace1", 0.4, 1 ],
+            [
+                "namespace1",
+                0.4,
+                1
+            ],
             true
         ],
         [
             "user 2, namespace2, 1",
             "2",
-            [ "namespace2", 0, 0.4 ],
+            [
+                "namespace2",
+                0,
+                0.4
+            ],
             false
         ],
         [
             "user 2, namespace2, 2",
             "2",
-            [ "namespace2", 0.4, 1 ],
+            [
+                "namespace2",
+                0.4,
+                1
+            ],
             true
         ],
         [
             "user 3, namespace1, 1",
             "3",
-            [ "namespace1", 0, 0.4 ],
+            [
+                "namespace1",
+                0,
+                0.4
+            ],
             false
         ],
         [
             "user 3, namespace1, 2",
             "3",
-            [ "namespace1", 0.4, 1 ],
+            [
+                "namespace1",
+                0.4,
+                1
+            ],
             true
         ],
         [
             "user 3, namespace2, 1",
             "3",
-            [ "namespace2", 0, 0.4 ],
+            [
+                "namespace2",
+                0,
+                0.4
+            ],
             true
         ],
         [
             "user 3, namespace2, 2",
             "3",
-            [ "namespace2", 0.4, 1 ],
+            [
+                "namespace2",
+                0.4,
+                1
+            ],
             false
         ],
         [
             "user 4, namespace1, 1",
             "4",
-            [ "namespace1", 0, 0.4 ],
+            [
+                "namespace1",
+                0,
+                0.4
+            ],
             false
         ],
         [
             "user 4, namespace1, 2",
             "4",
-            [ "namespace1", 0.4, 1 ],
+            [
+                "namespace1",
+                0.4,
+                1
+            ],
             true
         ],
         [
             "user 4, namespace2, 1",
             "4",
-            [ "namespace2", 0, 0.4 ],
+            [
+                "namespace2",
+                0,
+                0.4
+            ],
             true
         ],
         [
             "user 4, namespace2, 2",
             "4",
-            [ "namespace2", 0.4, 1 ],
+            [
+                "namespace2",
+                0.4,
+                1
+            ],
             false
         ]
     ],
@@ -6061,19 +8371,33 @@
         ],
         [
             1,
-            [ 1 ]
+            [
+                1
+            ]
         ],
         [
             2,
-            [ 0.5, 0.5 ]
+            [
+                0.5,
+                0.5
+            ]
         ],
         [
             3,
-            [ 0.33333333, 0.33333333, 0.33333333 ]
+            [
+                0.33333333,
+                0.33333333,
+                0.33333333
+            ]
         ],
         [
             4,
-            [ 0.25, 0.25, 0.25, 0.25 ]
+            [
+                0.25,
+                0.25,
+                0.25,
+                0.25
+            ]
         ]
     ],
     "decrypt": [
@@ -6142,13 +8466,20 @@
         [
             "use fallbackAttribute when missing hashAttribute",
             {
-                "attributes": { "anonymousId": "123" },
+                "attributes": {
+                    "anonymousId": "123"
+                },
                 "features": {
                     "feature": {
                         "defaultValue": 0,
                         "rules": [
                             {
-                                "variations": [ 0, 1, 2, 3 ],
+                                "variations": [
+                                    0,
+                                    1,
+                                    2,
+                                    3
+                                ],
                                 "hashAttribute": "id",
                                 "fallbackAttribute": "anonymousId"
                             }
@@ -6172,7 +8503,9 @@
             },
             {
                 "anonymousId||123": {
-                    "assignments": { "feature__0": "3" },
+                    "assignments": {
+                        "feature__0": "3"
+                    },
                     "attributeName": "anonymousId",
                     "attributeValue": "123"
                 }
@@ -6198,15 +8531,31 @@
                                 "fallbackAttribute": "deviceId",
                                 "hashVersion": 2,
                                 "bucketVersion": 0,
-                                "condition": { "country": "USA" },
-                                "variations": [ "control", "red", "blue" ],
+                                "condition": {
+                                    "country": "USA"
+                                },
+                                "variations": [
+                                    "control",
+                                    "red",
+                                    "blue"
+                                ],
                                 "meta": [
-                                    { "key": "0" },
-                                    { "key": "1" },
-                                    { "key": "2" }
+                                    {
+                                        "key": "0"
+                                    },
+                                    {
+                                        "key": "1"
+                                    },
+                                    {
+                                        "key": "2"
+                                    }
                                 ],
                                 "coverage": 1,
-                                "weights": [ 0.3334, 0.3333, 0.3333 ],
+                                "weights": [
+                                    0.3334,
+                                    0.3333,
+                                    0.3333
+                                ],
                                 "phase": "0"
                             }
                         ]
@@ -6230,7 +8579,9 @@
             },
             {
                 "deviceId||d123": {
-                    "assignments": { "feature-exp__0": "1" },
+                    "assignments": {
+                        "feature-exp__0": "1"
+                    },
                     "attributeName": "deviceId",
                     "attributeValue": "d123"
                 }
@@ -6256,15 +8607,31 @@
                                 "fallbackAttribute": "deviceId",
                                 "hashVersion": 2,
                                 "bucketVersion": 0,
-                                "condition": { "country": "USA" },
-                                "variations": [ "control", "red", "blue" ],
+                                "condition": {
+                                    "country": "USA"
+                                },
+                                "variations": [
+                                    "control",
+                                    "red",
+                                    "blue"
+                                ],
                                 "meta": [
-                                    { "key": "0" },
-                                    { "key": "1" },
-                                    { "key": "2" }
+                                    {
+                                        "key": "0"
+                                    },
+                                    {
+                                        "key": "1"
+                                    },
+                                    {
+                                        "key": "2"
+                                    }
                                 ],
                                 "coverage": 1,
-                                "weights": [ 0.3334, 0.3333, 0.3333 ],
+                                "weights": [
+                                    0.3334,
+                                    0.3333,
+                                    0.3333
+                                ],
                                 "phase": "0"
                             }
                         ]
@@ -6295,7 +8662,9 @@
             },
             {
                 "deviceId||d123": {
-                    "assignments": { "feature-exp__0": "2" },
+                    "assignments": {
+                        "feature-exp__0": "2"
+                    },
                     "attributeName": "deviceId",
                     "attributeValue": "d123"
                 }
@@ -6321,15 +8690,31 @@
                                 "fallbackAttribute": "deviceId",
                                 "hashVersion": 2,
                                 "bucketVersion": 0,
-                                "condition": { "country": "USA" },
-                                "variations": [ "control", "red", "blue" ],
+                                "condition": {
+                                    "country": "USA"
+                                },
+                                "variations": [
+                                    "control",
+                                    "red",
+                                    "blue"
+                                ],
                                 "meta": [
-                                    { "key": "0" },
-                                    { "key": "1" },
-                                    { "key": "2" }
+                                    {
+                                        "key": "0"
+                                    },
+                                    {
+                                        "key": "1"
+                                    },
+                                    {
+                                        "key": "2"
+                                    }
                                 ],
                                 "coverage": 1,
-                                "weights": [ 0.3334, 0.3333, 0.3333 ],
+                                "weights": [
+                                    0.3334,
+                                    0.3333,
+                                    0.3333
+                                ],
                                 "phase": "0"
                             }
                         ]
@@ -6360,7 +8745,9 @@
             },
             {
                 "deviceId||d123": {
-                    "assignments": { "feature-exp__0": "1" },
+                    "assignments": {
+                        "feature-exp__0": "1"
+                    },
                     "attributeName": "deviceId",
                     "attributeValue": "d123"
                 }
@@ -6386,15 +8773,31 @@
                                 "fallbackAttribute": "anonymousId",
                                 "hashVersion": 2,
                                 "bucketVersion": 0,
-                                "condition": { "country": "USA" },
-                                "variations": [ "control", "red", "blue" ],
+                                "condition": {
+                                    "country": "USA"
+                                },
+                                "variations": [
+                                    "control",
+                                    "red",
+                                    "blue"
+                                ],
                                 "meta": [
-                                    { "key": "0" },
-                                    { "key": "1" },
-                                    { "key": "2" }
+                                    {
+                                        "key": "0"
+                                    },
+                                    {
+                                        "key": "1"
+                                    },
+                                    {
+                                        "key": "2"
+                                    }
                                 ],
                                 "coverage": 1,
-                                "weights": [ 0.3334, 0.3333, 0.3333 ],
+                                "weights": [
+                                    0.3334,
+                                    0.3333,
+                                    0.3333
+                                ],
                                 "phase": "0"
                             }
                         ]
@@ -6425,12 +8828,16 @@
             },
             {
                 "anonymousId||ses123": {
-                    "assignments": { "feature-exp__0": "1" },
+                    "assignments": {
+                        "feature-exp__0": "1"
+                    },
                     "attributeName": "anonymousId",
                     "attributeValue": "ses123"
                 },
                 "id||i123": {
-                    "assignments": { "feature-exp__0": "1" },
+                    "assignments": {
+                        "feature-exp__0": "1"
+                    },
                     "attributeName": "id",
                     "attributeValue": "i123"
                 }
@@ -6456,15 +8863,31 @@
                                 "fallbackAttribute": "anonymousId",
                                 "hashVersion": 2,
                                 "bucketVersion": 0,
-                                "condition": { "country": "USA" },
-                                "variations": [ "control", "red", "blue" ],
+                                "condition": {
+                                    "country": "USA"
+                                },
+                                "variations": [
+                                    "control",
+                                    "red",
+                                    "blue"
+                                ],
                                 "meta": [
-                                    { "key": "0" },
-                                    { "key": "1" },
-                                    { "key": "2" }
+                                    {
+                                        "key": "0"
+                                    },
+                                    {
+                                        "key": "1"
+                                    },
+                                    {
+                                        "key": "2"
+                                    }
                                 ],
                                 "coverage": 1,
-                                "weights": [ 0.3334, 0.3333, 0.3333 ],
+                                "weights": [
+                                    0.3334,
+                                    0.3333,
+                                    0.3333
+                                ],
                                 "phase": "0"
                             }
                         ]
@@ -6502,12 +8925,16 @@
             },
             {
                 "anonymousId||ses123": {
-                    "assignments": { "feature-exp__0": "2" },
+                    "assignments": {
+                        "feature-exp__0": "2"
+                    },
                     "attributeName": "anonymousId",
                     "attributeValue": "ses123"
                 },
                 "id||i123": {
-                    "assignments": { "feature-exp__0": "1" },
+                    "assignments": {
+                        "feature-exp__0": "1"
+                    },
                     "attributeName": "id",
                     "attributeValue": "i123"
                 }
@@ -6532,15 +8959,31 @@
                                 "fallbackAttribute": "deviceId",
                                 "hashVersion": 2,
                                 "bucketVersion": 3,
-                                "condition": { "country": "USA" },
-                                "variations": [ "control", "red", "blue" ],
+                                "condition": {
+                                    "country": "USA"
+                                },
+                                "variations": [
+                                    "control",
+                                    "red",
+                                    "blue"
+                                ],
                                 "meta": [
-                                    { "key": "0" },
-                                    { "key": "1" },
-                                    { "key": "2" }
+                                    {
+                                        "key": "0"
+                                    },
+                                    {
+                                        "key": "1"
+                                    },
+                                    {
+                                        "key": "2"
+                                    }
                                 ],
                                 "coverage": 1,
-                                "weights": [ 0.3334, 0.3333, 0.3333 ],
+                                "weights": [
+                                    0.3334,
+                                    0.3333,
+                                    0.3333
+                                ],
                                 "phase": "0"
                             }
                         ]
@@ -6549,7 +8992,9 @@
             },
             [
                 {
-                    "assignments": { "feature-exp__0": "1" },
+                    "assignments": {
+                        "feature-exp__0": "1"
+                    },
                     "attributeName": "id",
                     "attributeValue": "i123"
                 }
@@ -6598,15 +9043,31 @@
                                 "hashVersion": 2,
                                 "bucketVersion": 3,
                                 "minBucketVersion": 3,
-                                "condition": { "country": "USA" },
-                                "variations": [ "control", "red", "blue" ],
+                                "condition": {
+                                    "country": "USA"
+                                },
+                                "variations": [
+                                    "control",
+                                    "red",
+                                    "blue"
+                                ],
                                 "meta": [
-                                    { "key": "0" },
-                                    { "key": "1" },
-                                    { "key": "2" }
+                                    {
+                                        "key": "0"
+                                    },
+                                    {
+                                        "key": "1"
+                                    },
+                                    {
+                                        "key": "2"
+                                    }
                                 ],
                                 "coverage": 1,
-                                "weights": [ 0.3334, 0.3333, 0.3333 ],
+                                "weights": [
+                                    0.3334,
+                                    0.3333,
+                                    0.3333
+                                ],
                                 "phase": "0"
                             }
                         ]
@@ -6615,7 +9076,9 @@
             },
             [
                 {
-                    "assignments": { "feature-exp__0": "1" },
+                    "assignments": {
+                        "feature-exp__0": "1"
+                    },
                     "attributeName": "id",
                     "attributeValue": "i123"
                 }
@@ -6629,6 +9092,333 @@
                     },
                     "attributeName": "id",
                     "attributeValue": "i123"
+                }
+            }
+        ],
+        [
+            "uses a sticky bucket when sticky bucket version == experiment.minBucketVersion === experiment.bucketVersion",
+            {
+                "attributes": {
+                    "deviceId": "d123",
+                    "anonymousId": "ses123",
+                    "foo": "bar",
+                    "country": "USA"
+                },
+                "features": {
+                    "exp1": {
+                        "defaultValue": "control",
+                        "rules": [
+                            {
+                                "key": "feature-exp",
+                                "seed": "feature-exp",
+                                "hashAttribute": "id",
+                                "fallbackAttribute": "deviceId",
+                                "hashVersion": 2,
+                                "bucketVersion": 3,
+                                "minBucketVersion": 3,
+                                "condition": {
+                                    "country": "USA"
+                                },
+                                "variations": [
+                                    "control",
+                                    "red",
+                                    "blue"
+                                ],
+                                "meta": [
+                                    {
+                                        "key": "0"
+                                    },
+                                    {
+                                        "key": "1"
+                                    },
+                                    {
+                                        "key": "2"
+                                    }
+                                ],
+                                "coverage": 1,
+                                "weights": [
+                                    0.3334,
+                                    0.3333,
+                                    0.3333
+                                ],
+                                "phase": "0"
+                            }
+                        ]
+                    }
+                }
+            },
+            [
+                {
+                    "attributeName": "deviceId",
+                    "attributeValue": "d123",
+                    "assignments": {
+                        "feature-exp__3": "2"
+                    }
+                }
+            ],
+            "exp1",
+            {
+                "bucket": 0.6468,
+                "featureId": "exp1",
+                "hashAttribute": "deviceId",
+                "hashUsed": true,
+                "hashValue": "d123",
+                "inExperiment": true,
+                "key": "2",
+                "stickyBucketUsed": true,
+                "value": "blue",
+                "variationId": 2
+            },
+            {
+                "deviceId||d123": {
+                    "assignments": {
+                        "feature-exp__3": "2"
+                    },
+                    "attributeName": "deviceId",
+                    "attributeValue": "d123"
+                }
+            }
+        ],
+        [
+            "skips assignment when sticky bucket version < experiment.minBucketVersion",
+            {
+                "attributes": {
+                    "deviceId": "d123",
+                    "anonymousId": "ses123",
+                    "foo": "bar",
+                    "country": "USA"
+                },
+                "features": {
+                    "exp1": {
+                        "defaultValue": "control",
+                        "rules": [
+                            {
+                                "key": "feature-exp",
+                                "seed": "feature-exp",
+                                "hashAttribute": "id",
+                                "fallbackAttribute": "deviceId",
+                                "hashVersion": 2,
+                                "bucketVersion": 3,
+                                "minBucketVersion": 3,
+                                "condition": {
+                                    "country": "USA"
+                                },
+                                "variations": [
+                                    "control",
+                                    "red",
+                                    "blue"
+                                ],
+                                "meta": [
+                                    {
+                                        "key": "0"
+                                    },
+                                    {
+                                        "key": "1"
+                                    },
+                                    {
+                                        "key": "2"
+                                    }
+                                ],
+                                "coverage": 1,
+                                "weights": [
+                                    0.3334,
+                                    0.3333,
+                                    0.3333
+                                ],
+                                "phase": "0"
+                            }
+                        ]
+                    }
+                }
+            },
+            [
+                {
+                    "attributeName": "deviceId",
+                    "attributeValue": "d123",
+                    "assignments": {
+                        "feature-exp__2": "2"
+                    }
+                }
+            ],
+            "exp1",
+            null,
+            {
+                "deviceId||d123": {
+                    "assignments": {
+                        "feature-exp__2": "2"
+                    },
+                    "attributeName": "deviceId",
+                    "attributeValue": "d123"
+                }
+            }
+        ],
+        [
+            "resets sticky bucketing when bucket version > experiment.bucketVersion (invalid version)",
+            {
+                "attributes": {
+                    "deviceId": "d123",
+                    "anonymousId": "ses123",
+                    "foo": "bar",
+                    "country": "USA"
+                },
+                "features": {
+                    "exp1": {
+                        "defaultValue": "control",
+                        "rules": [
+                            {
+                                "key": "feature-exp",
+                                "seed": "feature-exp",
+                                "hashAttribute": "id",
+                                "fallbackAttribute": "deviceId",
+                                "hashVersion": 2,
+                                "bucketVersion": 3,
+                                "minBucketVersion": 3,
+                                "condition": {
+                                    "country": "USA"
+                                },
+                                "variations": [
+                                    "control",
+                                    "red",
+                                    "blue"
+                                ],
+                                "meta": [
+                                    {
+                                        "key": "0"
+                                    },
+                                    {
+                                        "key": "1"
+                                    },
+                                    {
+                                        "key": "2"
+                                    }
+                                ],
+                                "coverage": 1,
+                                "weights": [
+                                    0.3334,
+                                    0.3333,
+                                    0.3333
+                                ],
+                                "phase": "0"
+                            }
+                        ]
+                    }
+                }
+            },
+            [
+                {
+                    "attributeName": "deviceId",
+                    "attributeValue": "d123",
+                    "assignments": {
+                        "feature-exp__4": "2"
+                    }
+                }
+            ],
+            "exp1",
+            {
+                "bucket": 0.6468,
+                "featureId": "exp1",
+                "hashAttribute": "deviceId",
+                "hashUsed": true,
+                "hashValue": "d123",
+                "inExperiment": true,
+                "key": "1",
+                "stickyBucketUsed": false,
+                "value": "red",
+                "variationId": 1
+            },
+            {
+                "deviceId||d123": {
+                    "assignments": {
+                        "feature-exp__3": "1",
+                        "feature-exp__4": "2"
+                    },
+                    "attributeName": "deviceId",
+                    "attributeValue": "d123"
+                }
+            }
+        ],
+        [
+            "resets sticky bucketing when bucket version < experiment.bucketVersion (invalid version)",
+            {
+                "attributes": {
+                    "deviceId": "d123",
+                    "anonymousId": "ses123",
+                    "foo": "bar",
+                    "country": "USA"
+                },
+                "features": {
+                    "exp1": {
+                        "defaultValue": "control",
+                        "rules": [
+                            {
+                                "key": "feature-exp",
+                                "seed": "feature-exp",
+                                "hashAttribute": "id",
+                                "fallbackAttribute": "deviceId",
+                                "hashVersion": 2,
+                                "bucketVersion": 4,
+                                "minBucketVersion": 3,
+                                "condition": {
+                                    "country": "USA"
+                                },
+                                "variations": [
+                                    "control",
+                                    "red",
+                                    "blue"
+                                ],
+                                "meta": [
+                                    {
+                                        "key": "0"
+                                    },
+                                    {
+                                        "key": "1"
+                                    },
+                                    {
+                                        "key": "2"
+                                    }
+                                ],
+                                "coverage": 1,
+                                "weights": [
+                                    0.3334,
+                                    0.3333,
+                                    0.3333
+                                ],
+                                "phase": "0"
+                            }
+                        ]
+                    }
+                }
+            },
+            [
+                {
+                    "attributeName": "deviceId",
+                    "attributeValue": "d123",
+                    "assignments": {
+                        "feature-exp__3": "2"
+                    }
+                }
+            ],
+            "exp1",
+            {
+                "bucket": 0.6468,
+                "featureId": "exp1",
+                "hashAttribute": "deviceId",
+                "hashUsed": true,
+                "hashValue": "d123",
+                "inExperiment": true,
+                "key": "1",
+                "stickyBucketUsed": false,
+                "value": "red",
+                "variationId": 1
+            },
+            {
+                "deviceId||d123": {
+                    "assignments": {
+                        "feature-exp__3": "2",
+                        "feature-exp__4": "1"
+                    },
+                    "attributeName": "deviceId",
+                    "attributeValue": "d123"
                 }
             }
         ],
@@ -6652,15 +9442,31 @@
                                 "hashVersion": 2,
                                 "bucketVersion": 1,
                                 "disableStickyBucketing": true,
-                                "condition": { "country": "USA" },
-                                "variations": [ "control", "red", "blue" ],
+                                "condition": {
+                                    "country": "USA"
+                                },
+                                "variations": [
+                                    "control",
+                                    "red",
+                                    "blue"
+                                ],
                                 "meta": [
-                                    { "key": "0" },
-                                    { "key": "1" },
-                                    { "key": "2" }
+                                    {
+                                        "key": "0"
+                                    },
+                                    {
+                                        "key": "1"
+                                    },
+                                    {
+                                        "key": "2"
+                                    }
                                 ],
                                 "coverage": 1,
-                                "weights": [ 0.3334, 0.3333, 0.3333 ],
+                                "weights": [
+                                    0.3334,
+                                    0.3333,
+                                    0.3333
+                                ],
                                 "phase": "0"
                             }
                         ]
@@ -6671,7 +9477,9 @@
                 {
                     "attributeName": "id",
                     "attributeValue": "i123",
-                    "assignments": { "feature-exp__0": "1" }
+                    "assignments": {
+                        "feature-exp__0": "1"
+                    }
                 }
             ],
             "exp1",
@@ -6691,7 +9499,9 @@
                 "id||i123": {
                     "attributeName": "id",
                     "attributeValue": "i123",
-                    "assignments": { "feature-exp__0": "1" }
+                    "assignments": {
+                        "feature-exp__0": "1"
+                    }
                 }
             }
         ]
@@ -6700,7 +9510,9 @@
         [
             "redirects correctly without query strings",
             {
-                "attributes": { "id": "1" },
+                "attributes": {
+                    "id": "1"
+                },
                 "url": "http://www.example.com/home",
                 "experiments": [
                     {
@@ -6712,7 +9524,10 @@
                                 "pattern": "http://www.example.com/home"
                             }
                         ],
-                        "weights": [ 0.1, 0.9 ],
+                        "weights": [
+                            0.1,
+                            0.9
+                        ],
                         "variations": [
                             {},
                             {
@@ -6733,7 +9548,9 @@
         [
             "redirects with query string on original url and persistQueryString enabled",
             {
-                "attributes": { "id": "1" },
+                "attributes": {
+                    "id": "1"
+                },
                 "url": "http://www.example.com/home?color=blue&food=sushi",
                 "experiments": [
                     {
@@ -6745,7 +9562,10 @@
                                 "pattern": "http://www.example.com/home"
                             }
                         ],
-                        "weights": [ 0.1, 0.9 ],
+                        "weights": [
+                            0.1,
+                            0.9
+                        ],
                         "variations": [
                             {},
                             {
@@ -6767,7 +9587,9 @@
         [
             "merges query strings on original url & redirect url with param conflicts correctly when persistQueryString enabled",
             {
-                "attributes": { "id": "1" },
+                "attributes": {
+                    "id": "1"
+                },
                 "url": "http://www.example.com/home?color=blue&food=sushi&title=original",
                 "experiments": [
                     {
@@ -6779,7 +9601,10 @@
                                 "pattern": "http://www.example.com/home"
                             }
                         ],
-                        "weights": [ 0.1, 0.9 ],
+                        "weights": [
+                            0.1,
+                            0.9
+                        ],
                         "variations": [
                             {},
                             {
@@ -6801,7 +9626,9 @@
         [
             "only performs a redirect for first eligible experiment when there are multiple eligible experiments",
             {
-                "attributes": { "id": "1" },
+                "attributes": {
+                    "id": "1"
+                },
                 "url": "http://www.example.com/home",
                 "experiments": [
                     {
@@ -6813,7 +9640,10 @@
                                 "pattern": "http://www.example.com/"
                             }
                         ],
-                        "weights": [ 0.1, 0.9 ],
+                        "weights": [
+                            0.1,
+                            0.9
+                        ],
                         "variations": [
                             {},
                             {
@@ -6830,7 +9660,10 @@
                                 "pattern": "http://www.example.com/home"
                             }
                         ],
-                        "weights": [ 0.1, 0.9 ],
+                        "weights": [
+                            0.1,
+                            0.9
+                        ],
                         "variations": [
                             {},
                             {
@@ -6847,7 +9680,10 @@
                                 "pattern": "http://www.example.com/home"
                             }
                         ],
-                        "weights": [ 0.1, 0.9 ],
+                        "weights": [
+                            0.1,
+                            0.9
+                        ],
                         "variations": [
                             {},
                             {

--- a/GrowthBook.Tests/StandardTests/StandardCasesMetadataTests.cs
+++ b/GrowthBook.Tests/StandardTests/StandardCasesMetadataTests.cs
@@ -36,7 +36,7 @@ public class StandardCasesMetadataTests
     {
         var standardCases = LoadStandardCases();
 
-        standardCases["specVersion"]?.ToString().Should().Be("0.7.0");
+        standardCases["specVersion"]?.ToString().Should().Be("0.7.1");
     }
 
     [Fact]

--- a/GrowthBook/Providers/ConditionEvaluationProvider.cs
+++ b/GrowthBook/Providers/ConditionEvaluationProvider.cs
@@ -214,25 +214,15 @@ namespace GrowthBook.Providers
 
             if (op == "$regex")
             {
-                try
-                {
-                    return Regex.IsMatch(attributeValue?.ToString(), conditionValue?.ToString());
-                }
-                catch (ArgumentException)
-                {
-                    return false;
-                }
+                return EvaluateRegex(attributeValue, conditionValue, RegexOptions.None, negate: false);
+            }
+            if (op == "$regexi")
+            {
+                return EvaluateRegex(attributeValue, conditionValue, RegexOptions.IgnoreCase, negate: false);
             }
             if (op == "$nregex")
             {
-                try
-                {
-                    return !Regex.IsMatch(attributeValue?.ToString(), conditionValue?.ToString());
-                }
-                catch (ArgumentException)
-                {
-                    return false;
-                }
+                return EvaluateRegex(attributeValue, conditionValue, RegexOptions.None, negate: true);
             }
             if (op == "$in")
             {
@@ -240,7 +230,15 @@ namespace GrowthBook.Providers
                 {
                     return false;
                 }
-                return IsIn(conditionValue, attributeValue, savedGroups);
+                return IsIn(conditionValue, attributeValue);
+            }
+            if (op == "$ini")
+            {
+                if (conditionValue.Type != JTokenType.Array)
+                {
+                    return false;
+                }
+                return IsIn(conditionValue, attributeValue, StringComparison.OrdinalIgnoreCase);
             }
             if (op == "$nin")
             {
@@ -248,31 +246,23 @@ namespace GrowthBook.Providers
                 {
                     return false;
                 }
-                return !IsIn(conditionValue, attributeValue, savedGroups);
+                return !IsIn(conditionValue, attributeValue);
             }
-            if (op == "$all")
+            if (op == "$nini")
             {
                 if (conditionValue.Type != JTokenType.Array)
                 {
                     return false;
                 }
-                if (attributeValue?.Type != JTokenType.Array)
-                {
-                    return false;
-                }
-
-                var conditionList = (JArray)conditionValue;
-                var attributeList = (JArray)attributeValue;
-
-                foreach (JToken condition in conditionList)
-                {
-                    if (!attributeList.Any(x => EvalConditionValue(condition, x, savedGroups)))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
+                return !IsIn(conditionValue, attributeValue, StringComparison.OrdinalIgnoreCase);
+            }
+            if (op == "$all")
+            {
+                return IsAll(conditionValue, attributeValue, savedGroups, stringComparison: null);
+            }
+            if (op == "$alli")
+            {
+                return IsAll(conditionValue, attributeValue, savedGroups, StringComparison.OrdinalIgnoreCase);
             }
 
             if (op == "$elemMatch")
@@ -337,7 +327,7 @@ namespace GrowthBook.Providers
                 {
                     var array = savedGroups[conditionValue.ToString()]?.AsArray() ?? new JArray();
 
-                    return IsIn(array, attributeValue, savedGroups);
+                    return IsIn(array, attributeValue);
                 }
             }
             if (op == "$notInGroup")
@@ -346,7 +336,7 @@ namespace GrowthBook.Providers
                 {
                     var array = savedGroups[conditionValue.ToString()]?.AsArray() ?? new JArray();
 
-                    return !IsIn(array, attributeValue, savedGroups);
+                    return !IsIn(array, attributeValue);
                 }
             }
 
@@ -401,28 +391,52 @@ namespace GrowthBook.Providers
             return true;
         }
 
-        private bool IsIn(JToken conditionValue, JToken actualValue, JObject savedGroups)
+        private static bool EvaluateRegex(JToken attributeValue, JToken conditionValue, RegexOptions options, bool negate)
+        {
+            if (attributeValue.IsNull() || conditionValue.IsNull())
+            {
+                return false;
+            }
+
+            try
+            {
+                var isMatch = Regex.IsMatch(attributeValue.ToString(), conditionValue.ToString(), options);
+
+                return negate ? !isMatch : isMatch;
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+        }
+
+        private bool IsIn(JToken conditionValue, JToken actualValue, StringComparison? stringComparison = null)
         {
             if (actualValue?.Type == JTokenType.Array)
             {
                 _logger.LogDebug("Evaluating whether the specified value is in an array");
 
-                var conditionValues = new HashSet<JToken>(conditionValue);
-                var actualValues = new HashSet<JToken>(actualValue);
+                if (stringComparison is null)
+                {
+                    var conditionValues = new HashSet<JToken>(conditionValue);
+                    var actualValues = new HashSet<JToken>(actualValue);
 
-                conditionValues.IntersectWith(actualValues);
+                    conditionValues.IntersectWith(actualValues);
 
-                return conditionValues.Any();
+                    return conditionValues.Any();
+                }
+
+                return conditionValue.Any(condition => actualValue.Any(actual => TokensEqual(condition, actual, stringComparison.Value)));
             }
             else if (conditionValue is JArray array)
             {
-                return array.Any(x => x.Equals(actualValue));
+                return array.Any(x => TokensEqual(x, actualValue, stringComparison));
             }
             else
             {
                 _logger.LogDebug("Evaluating whether the specified value is equal to or contained within the actual value");
 
-                if (conditionValue == actualValue)
+                if (TokensEqual(conditionValue, actualValue, stringComparison))
                 {
                     return true;
                 }
@@ -432,8 +446,55 @@ namespace GrowthBook.Providers
                     return false;
                 }
 
-                return conditionValue.ToString().Contains(actualValue.ToString());
+                return conditionValue.ToString().IndexOf(actualValue.ToString(), stringComparison ?? StringComparison.Ordinal) >= 0;
             }
+        }
+
+        private bool IsAll(JToken conditionValue, JToken attributeValue, JObject savedGroups, StringComparison? stringComparison)
+        {
+            if (conditionValue.Type != JTokenType.Array)
+            {
+                return false;
+            }
+            if (attributeValue?.Type != JTokenType.Array)
+            {
+                return false;
+            }
+
+            var conditionList = (JArray)conditionValue;
+            var attributeList = (JArray)attributeValue;
+
+            foreach (JToken condition in conditionList)
+            {
+                if (stringComparison is null)
+                {
+                    if (!attributeList.Any(x => EvalConditionValue(condition, x, savedGroups)))
+                    {
+                        return false;
+                    }
+                }
+                else if (!attributeList.Any(x => TokensEqual(condition, x, stringComparison)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool TokensEqual(JToken left, JToken right, StringComparison? stringComparison)
+        {
+            if (stringComparison is null)
+            {
+                return JToken.DeepEquals(left ?? JValue.CreateNull(), right ?? JValue.CreateNull());
+            }
+
+            if (left?.Type == JTokenType.String && right?.Type == JTokenType.String)
+            {
+                return string.Equals(left.ToString(), right.ToString(), stringComparison.Value);
+            }
+
+            return JToken.DeepEquals(left ?? JValue.CreateNull(), right ?? JValue.CreateNull());
         }
 
         private static bool CompareVersions(JToken left, JToken right, Func<int, bool> meetsComparison)
@@ -484,7 +545,8 @@ namespace GrowthBook.Providers
 
         /// <summary>
         /// Evaluates a comparison operation between an attribute value and a condition value.
-        /// Returns false if the attribute is null/missing, as null values should not satisfy any comparison.
+        /// Missing numeric attributes are compared as zero to match the standard fixture.
+        /// Explicit null values never satisfy comparison operators.
         /// </summary>
         /// <param name="attributeValue">The attribute value to compare.</param>
         /// <param name="conditionValue">The condition value to compare against.</param>
@@ -492,8 +554,18 @@ namespace GrowthBook.Providers
         /// <returns>True if the comparison is satisfied, false if attribute is null or comparison fails.</returns>
         private bool EvaluateComparison(JToken attributeValue, JToken conditionValue, Func<int, bool> meetsComparison)
         {
-            // Null/missing attributes should never satisfy comparison operators
-            if (attributeValue.IsNull())
+            if (attributeValue == null)
+            {
+                if (conditionValue.Type == JTokenType.Integer || conditionValue.Type == JTokenType.Float)
+                {
+                    return meetsComparison(0d.CompareTo(conditionValue.Value<double>()));
+                }
+
+                return false;
+            }
+
+            // Explicit null attributes should never satisfy comparison operators.
+            if (attributeValue.Type == JTokenType.Null)
             {
                 return false;
             }


### PR DESCRIPTION
## Summary

Reworks the useful parts of #77 to bring the C# SDK up to standard-cases `0.7.1`.

Adds support for the standard case-insensitive operators:
- `$ini`
- `$nini`
- `$regexi`
- `$alli`

Closes #77

Also preserves local-only regression cases while updating the shared standard fixture.

## Improvements over #77

- Uses `StringComparison.OrdinalIgnoreCase` instead of lowercasing strings manually.
- Avoids the Unicode/Cyrillic identifier issue in the helper implementation.
- Keeps explicit JSON `null` from satisfying numeric comparison operators.
- Does not add extra non-standard operator surface like `$notRegex` / `$notRegexi`.